### PR TITLE
change the way pattern name list is generated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CoGAPS
-Version: 3.21.5
-Date: 2023-03-18
+Version: 3.23.2
+Date: 2024-03-22
 Title: Coordinated Gene Activity in Pattern Sets
 Author: Jeanette Johnson, Ashley Tsang, Jacob Mitchell, Thomas Sherman, Wai-shing Lee, Conor Kelton, Ondrej Maxian, Jacob Carey,
     Genevieve Stein-O'Brien, Michael Considine, Maggie Wodicka, John Stansfield,

--- a/R/methods-CogapsResult.R
+++ b/R/methods-CogapsResult.R
@@ -482,18 +482,15 @@ function(object, threshold, lp, axis)
     else if (threshold == "all") # only the markers with the lowest scores
     {
         thresholdTest <- apply(markerScores, 1, which.min)
-        
         patternsByMarker <- rep(0, length(markerScores))
-        i=0
+        i <- 0
         for (gene in thresholdTest) {
-          print(names(gene))
           if (length(names(gene))){
-            patternsByMarker[i] = names(gene)
+            patternsByMarker[i] <- names(gene)
           }          
-          i = i+1
+          i <- i + 1
         }
 
-        # patternsByMarker <- colnames(markerScores)[apply(markerScores, 1, which.min)]
         markersByPattern <- sapply(colnames(markerScores), USE.NAMES=TRUE, simplify=FALSE,
             function(pattern) rownames(markerScores)[which(patternsByMarker==pattern)])
         

--- a/R/methods-CogapsResult.R
+++ b/R/methods-CogapsResult.R
@@ -481,7 +481,19 @@ function(object, threshold, lp, axis)
     }
     else if (threshold == "all") # only the markers with the lowest scores
     {
-        patternsByMarker <- colnames(markerScores)[apply(markerScores, 1, which.min)]
+        thresholdTest <- apply(markerScores, 1, which.min)
+        
+        patternsByMarker <- rep(0, length(markerScores))
+        i=0
+        for (gene in thresholdTest) {
+          print(names(gene))
+          if (length(names(gene))){
+            patternsByMarker[i] = names(gene)
+          }          
+          i = i+1
+        }
+
+        # patternsByMarker <- colnames(markerScores)[apply(markerScores, 1, which.min)]
         markersByPattern <- sapply(colnames(markerScores), USE.NAMES=TRUE, simplify=FALSE,
             function(pattern) rownames(markerScores)[which(patternsByMarker==pattern)])
         

--- a/tests/testthat/test_patternMarkers.R
+++ b/tests/testthat/test_patternMarkers.R
@@ -1,8 +1,32 @@
-test_that("patternMarkers work with threshold = 'all'", {
+test_that("patternMarkers work with threshold = 'all' for general mode", {
     #set up
     data(GIST)
-    res <- CoGAPS(GIST.data_frame, nIterations=100, outputFrequency=50, seed=1, messages=FALSE)
+    res <- CoGAPS(GIST.data_frame, nIterations=100,
+                  seed=1, messages=FALSE)
+    expect_no_error(patternMarkers(res, threshold = "all"))
+})
 
-    test <- patternMarkers(res, threshold = "all")
-    expect_gt(length(test$PatternMarkers), 0)
+test_that("patternMarkers work with threshold = 'all' for sparse mode", {
+    #set up
+    data(GIST)
+    res <- CoGAPS(GIST.data_frame, nIterations=100,
+                  seed=1, messages=FALSE, sparseOptimization=TRUE)
+    expect_no_error(patternMarkers(res, threshold = "all"))
+    
+})
+
+test_that("patternMarkers work with threshold = 'all' and axis = 2", {
+    #set up
+    data(GIST)
+    res <- CoGAPS(GIST.data_frame, nIterations=100,
+                  seed=1, messages=FALSE)
+    expect_no_error(patternMarkers(res, threshold = "all", axis = 2))
+})
+
+test_that("patternMarkers work with threshold = 'all' and axis = 1", {
+    #set up
+    data(GIST)
+    res <- CoGAPS(GIST.data_frame, nIterations=100,
+                  seed=1, messages=FALSE)
+    expect_no_error(patternMarkers(res, threshold = "all", axis = 1))
 })

--- a/tests/testthat/test_patternMarkers.R
+++ b/tests/testthat/test_patternMarkers.R
@@ -1,0 +1,8 @@
+test_that("patternMarkers work with threshold = 'all'", {
+    #set up
+    data(GIST)
+    res <- CoGAPS(GIST.data_frame, nIterations=100, outputFrequency=50, seed=1, messages=FALSE)
+
+    test <- patternMarkers(res, threshold = "all")
+    expect_gt(length(test$PatternMarkers), 0)
+})


### PR DESCRIPTION
This is addressing a bug report I received over slack.
<img width="716" alt="image" src="https://github.com/FertigLab/CoGAPS/assets/25310425/345cff31-f2b1-4140-af36-3f7017847e72">

I was able to reproduce the issue and saw it came from line 484, which is supposed to make a list of the name of the top pattern for each gene. It produced the error shown above.

<img width="738" alt="image" src="https://github.com/FertigLab/CoGAPS/assets/25310425/820bd8a4-6ab2-4c6b-9f01-af1ebcbb4934">

I commented that line and re-wrote the list comprehension logic as a simple for loop that compiles the list of all pattern names, and confirmed that this produced the expected output with no errors.

<img width="674" alt="image" src="https://github.com/FertigLab/CoGAPS/assets/25310425/fd750216-0891-42bc-8347-dd4f7d8ed75a">

My best guess as to the root cause: Possible change of base functionality in R version? I think maybe something that used to return a list now returns a list of lists, but I am not positive. The code I re-wrote generates a list, which the next line expects as input to compute the final statistic. I do not expect this change to affect any other part of the code.