### PR TITLE
getPatternGeneSet: replace pathways column with gene.set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CoGAPS
-Version: 3.24.0
+Version: 3.24.1
 Date: 2024-03-22
 Title: Coordinated Gene Activity in Pattern Sets
 Author: Jeanette Johnson, Ashley Tsang, Jacob Mitchell, Thomas Sherman, Wai-shing Lee, Conor Kelton, Ondrej Maxian, Jacob Carey,

--- a/R/methods-CogapsResult.R
+++ b/R/methods-CogapsResult.R
@@ -311,10 +311,10 @@ function(object, gene.sets, method = c("enrichment", "overrepresentation"), ...)
         amp <- A[,p]
         names(amp) <- features
         result <- fgsea::fgsea(pathways = gene.sets, stats = amp, scoreType = "pos")
+        result <- dplyr::rename(result, gene.set = "pathway")
+        result <- dplyr::mutate(result,gene.set=forcats::fct_reorder(gene.set, - padj))
         result$leadingEdge <- vapply(result$leadingEdge, FUN = toString, FUN.VALUE = character(1))
         result$neg.log.padj <- (-10) * log10(result$padj)
-        result$gene.set <- names(gene.sets)
-        result <- dplyr::mutate(result,gene.set=forcats::fct_reorder(gene.set, - padj))
         return(result)
       }
     )
@@ -332,10 +332,10 @@ function(object, gene.sets, method = c("enrichment", "overrepresentation"), ...)
           pathways = gene.sets, genes = PMlist[[p]],
           universe = features,
           maxSize=2038)
+        result <- dplyr::rename(result, gene.set = "pathway")
+        result <- dplyr::mutate(result,gene.set=forcats::fct_reorder(gene.set, - padj))
         result[["k/K"]] <- result$overlap / result$size
         result$neg.log.padj <- (-10) * log10(result$padj)
-        result$gene.set <- names(gene.sets)
-        result <- dplyr::mutate(result,gene.set=forcats::fct_reorder(gene.set, - padj))
         return(result)
       }
     )

--- a/tests/testthat/test_getPatternGeneSet.R
+++ b/tests/testthat/test_getPatternGeneSet.R
@@ -2,6 +2,7 @@ test_that("getPatternGeneSet works on enrichment test", {
   #set up
   data(GIST)
   gs.test <- list(
+    "sig_p1" = c("Hs.479754", "Hs.491582", "Hs.155591", "Hs.443625", "Hs.170355","Hs.191911"),
     "gs1" = c("Hs.2", "Hs.4", "Hs.36", "Hs.96", "Hs.202"),
     "gs2" = c("Hs.699463", "Hs.699288", "Hs.699280", "Hs.699154", "Hs.697294")
   )
@@ -12,6 +13,7 @@ test_that("getPatternGeneSet works on overrepresentation test", {
   #set up
   data(GIST)
   gs.test <- list(
+    "sig_p1" = c("Hs.479754", "Hs.491582", "Hs.155591", "Hs.443625", "Hs.170355","Hs.191911"),
     "gs1" = c("Hs.2", "Hs.4", "Hs.36", "Hs.96", "Hs.202"),
     "gs2" = c("Hs.699463", "Hs.699288", "Hs.699280", "Hs.699154", "Hs.697294")
   )
@@ -22,10 +24,15 @@ test_that("plotPatternGeneSet renders a plot for enrichment test", {
   #set up
   data(GIST)
   gs.test <- list(
+    "sig_p1" = c("Hs.479754", "Hs.491582", "Hs.155591", "Hs.443625", "Hs.170355","Hs.191911"),
     "gs1" = c("Hs.2", "Hs.4", "Hs.36", "Hs.96", "Hs.202"),
     "gs2" = c("Hs.699463", "Hs.699288", "Hs.699280", "Hs.699154", "Hs.697294")
   )
   gpgs_res <- getPatternGeneSet(object = GIST.result, gene.sets = gs.test, method = "enrichment")
+  significant_result <- gpgs_res[[1]][gpgs_res[[1]]$gene.set == "sig_p1",]
+  
+  expect_true(significant_result$padj < 0.05)
+  
   pl <- plotPatternGeneSet(patterngeneset = gpgs_res, whichpattern = 1, padj_threshold = 1)
   
   expect_is(pl$layers[[1]], "ggproto")
@@ -36,10 +43,15 @@ test_that("plotPatternGeneSet renders a plot for overrepresentation test", {
   #set up
   data(GIST)
   gs.test <- list(
+    "sig_p1" = c("Hs.479754", "Hs.491582", "Hs.155591", "Hs.443625", "Hs.170355","Hs.191911"),
     "gs1" = c("Hs.2", "Hs.4", "Hs.36", "Hs.96", "Hs.202"),
     "gs2" = c("Hs.699463", "Hs.699288", "Hs.699280", "Hs.699154", "Hs.697294")
   )
   gpgs_res <- getPatternGeneSet(object = GIST.result, gene.sets = gs.test, method = "overrepresentation", threshold = "cut")
+  significant_result <- gpgs_res[[1]][gpgs_res[[1]]$gene.set == "sig_p1",]
+  
+  expect_true(significant_result$padj < 0.05)
+  
   pl <- plotPatternGeneSet(patterngeneset = gpgs_res, whichpattern = 1, padj_threshold = 1)
   
   expect_is(pl$layers[[1]], "ggproto")


### PR DESCRIPTION
Avoids redundant data frame column issue by renaming the "pathways" column to "gene.set" before converting this column to a factor ordered by adjusted p-value.