### PR TITLE
Add compiler reproducibility diagnostics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ biocViews: GeneExpression, Transcription, GeneSetEnrichment,
     DifferentialExpression, Bayesian, Clustering, TimeCourse, RNASeq, Microarray,
     MultipleComparison, DimensionReduction, ImmunoOncology
 NeedsCompilation: yes
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8
 Collate:
     'class-CogapsParams.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CoGAPS
-Version: 3.33.0
+Version: 3.33.1
 Date: 2025-03-11
 Title: Coordinated Gene Activity in Pattern Sets
 Author: Jeanette Johnson, Ashley Tsang, Jacob Mitchell, Thomas Sherman, Wai-shing Lee, Conor Kelton, Ondrej Maxian, Jacob Carey,

--- a/R/CoGAPS.R
+++ b/R/CoGAPS.R
@@ -104,7 +104,8 @@ CoGAPS <- function(data, params=new("CogapsParams", nPatterns=nPatterns),
     params <- getValueOrRds(params)
     validObject(params)
 
-    # check OpenMP support
+    # OpenMP availability determines whether the asynchronous sampler can run.
+    # Without OpenMP, CoGAPS falls back to the sequential sampler path.
     if (!compiledWithOpenMPSupport())
     {
         if (asynchronousUpdates | nThreads > 1)

--- a/R/CoGAPS.R
+++ b/R/CoGAPS.R
@@ -107,8 +107,12 @@ CoGAPS <- function(data, params=new("CogapsParams", nPatterns=nPatterns),
     # check OpenMP support
     if (!compiledWithOpenMPSupport())
     {
-        if (asynchronousUpdates & nThreads > 1)
-            warning("requesting multi-threaded version of CoGAPS but compiler did not support OpenMP")
+        if (asynchronousUpdates | nThreads > 1)
+            warning(paste(
+                "OpenMP is not available in this CoGAPS build;",
+                "running with asynchronousUpdates=FALSE and nThreads=1;",
+                "this may change results in a platform-dependent manner."
+            ))
         asynchronousUpdates = FALSE
         nThreads = 1
     }

--- a/R/CoGAPS.R
+++ b/R/CoGAPS.R
@@ -91,7 +91,7 @@ CoGAPS <- function(data, params=new("CogapsParams", nPatterns=nPatterns),
                    nPatterns, nThreads=1, messages=TRUE, outputFrequency=1000,
                    uncertainty=NULL, checkpointOutFile="gaps_checkpoint.out",
                    checkpointInterval=0, checkpointInFile=NULL, transposeData=FALSE,
-                   BPPARAM=NULL, workerID=1, asynchronousUpdates=TRUE, nSnapshots=0,
+                   BPPARAM=NULL, workerID=1, asynchronousUpdates=FALSE, nSnapshots=0,
                    snapshotPhase='sampling', ...)
 {
     # pre-process inputs

--- a/R/DistributedCogaps.R
+++ b/R/DistributedCogaps.R
@@ -25,6 +25,10 @@ workerID)
     allParams$gaps@subsetIndices <- subsetIndices
     allParams$gaps@subsetDim <- ifelse(genomeWide, 1, 2)
     allParams$workerID <- workerID
+
+    # Distributed CoGAPS parallelizes across data subsets instead of using the
+    # OpenMP asynchronous sampler within each worker. Each worker is therefore
+    # run with asynchronousUpdates=FALSE and nThreads=1.
     allParams$asynchronousUpdates <- FALSE
     allParams$nThreads <- 1
 

--- a/R/HelperFunctions.R
+++ b/R/HelperFunctions.R
@@ -232,8 +232,12 @@ checkInputs <- function(data, uncertainty, allParams)
 
     if (!is.null(allParams$gaps@distributed))
     {
-        if (allParams$nThreads > 1)
-            warning("can't run multi-threaded and distributed CoGAPS at the same time, ignoring nThreads")
+        if (allParams$asynchronousUpdates | allParams$nThreads > 1)
+            warning(paste(
+                "Distributed CoGAPS parallelizes across data subsets and does",
+                "not use OpenMP asynchronous updates within each worker;",
+                "running workers with asynchronousUpdates=FALSE and nThreads=1."
+            ))
         if (!is.null(allParams$checkpointInFile))
             stop("checkpoints not supported for distributed cogaps")
         if (!is(data, "character"))

--- a/inst/scripts/debugCompilerReproducibilityFingerprint.R
+++ b/inst/scripts/debugCompilerReproducibilityFingerprint.R
@@ -1,5 +1,9 @@
 #!/usr/bin/env Rscript
 
+# this script is not used anywhere in the CoGAPS package, it has been written 
+# by codex AI to debug reproducibility in CoGAPS results across different
+# compiler versions and platforms.
+
 suppressPackageStartupMessages(library(CoGAPS))
 
 parseArgs <- function(args)

--- a/inst/scripts/debugCompilerReproducibilityFingerprint.R
+++ b/inst/scripts/debugCompilerReproducibilityFingerprint.R
@@ -1,0 +1,173 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages(library(CoGAPS))
+
+parseArgs <- function(args)
+{
+    defaults <- list(
+        out = "debug_compiler_reproducibility_fingerprint.tsv",
+        seed = 42,
+        nIterations = 100,
+        nPatterns = 7,
+        outputFrequency = 10,
+        repeats = 1
+    )
+
+    for (arg in args)
+    {
+        parts <- strsplit(sub("^--", "", arg), "=", fixed=TRUE)[[1]]
+        if (length(parts) != 2)
+            stop("arguments must use --name=value format: ", arg)
+        name <- parts[1]
+        value <- parts[2]
+        if (!name %in% names(defaults))
+            stop("unknown argument: ", name)
+        if (name == "out")
+            defaults[[name]] <- value
+        else
+            defaults[[name]] <- as.numeric(value)
+    }
+
+    defaults
+}
+
+hashObject <- function(x)
+{
+    path <- tempfile(fileext=".rds")
+    on.exit(unlink(path), add=TRUE)
+    saveRDS(x, path, version=2)
+    unname(tools::md5sum(path))
+}
+
+summarizeMatrix <- function(x)
+{
+    c(
+        hash=hashObject(x),
+        nrow=nrow(x),
+        ncol=ncol(x),
+        sum=signif(sum(x), 16),
+        mean=signif(mean(x), 16),
+        min=signif(min(x), 16),
+        max=signif(max(x), 16)
+    )
+}
+
+resultFingerprint <- function(result)
+{
+    featureLoadings <- summarizeMatrix(result@featureLoadings)
+    sampleFactors <- summarizeMatrix(result@sampleFactors)
+    loadingStdDev <- summarizeMatrix(result@loadingStdDev)
+    factorStdDev <- summarizeMatrix(result@factorStdDev)
+
+    c(
+        featureLoadings_hash=unname(featureLoadings["hash"]),
+        featureLoadings_sum=unname(featureLoadings["sum"]),
+        sampleFactors_hash=unname(sampleFactors["hash"]),
+        sampleFactors_sum=unname(sampleFactors["sum"]),
+        loadingStdDev_hash=unname(loadingStdDev["hash"]),
+        loadingStdDev_sum=unname(loadingStdDev["sum"]),
+        factorStdDev_hash=unname(factorStdDev["hash"]),
+        factorStdDev_sum=unname(factorStdDev["sum"]),
+        atomsA_hash=hashObject(result@metadata$atomsA),
+        atomsP_hash=hashObject(result@metadata$atomsP),
+        chisq_hash=hashObject(result@metadata$chisq),
+        meanChiSq=signif(result@metadata$meanChiSq, 16)
+    )
+}
+
+runMode <- function(data, opts, modeName, sparseOptimization,
+asynchronousUpdates, nThreads, repeatIndex)
+{
+    effectiveAsynchronousUpdates <- asynchronousUpdates
+    effectiveNThreads <- nThreads
+    if (!CoGAPS::compiledWithOpenMPSupport())
+    {
+        effectiveAsynchronousUpdates <- FALSE
+        effectiveNThreads <- 1
+    }
+
+    result <- NULL
+    suppressWarnings(
+        suppressMessages(
+            capture.output(
+                result <- CoGAPS(
+                    data,
+                    nPatterns=opts$nPatterns,
+                    nIterations=opts$nIterations,
+                    outputFrequency=opts$outputFrequency,
+                    seed=opts$seed,
+                    messages=FALSE,
+                    sparseOptimization=sparseOptimization,
+                    asynchronousUpdates=asynchronousUpdates,
+                    nThreads=nThreads
+                )
+            )
+        )
+    )
+
+    c(
+        mode=modeName,
+        repeatIndex=repeatIndex,
+        seed=opts$seed,
+        nIterations=opts$nIterations,
+        nPatterns=opts$nPatterns,
+        requestedSparseOptimization=sparseOptimization,
+        requestedAsynchronousUpdates=asynchronousUpdates,
+        requestedNThreads=nThreads,
+        effectiveAsynchronousUpdates=effectiveAsynchronousUpdates,
+        effectiveNThreads=effectiveNThreads,
+        resultFingerprint(result)
+    )
+}
+
+opts <- parseArgs(commandArgs(trailingOnly=TRUE))
+
+data(GIST)
+data <- GIST.matrix
+
+buildReportText <- gsub("[\r\n\t]+", " | ", CoGAPS::buildReport())
+metadata <- c(
+    packageVersion=as.character(utils::packageVersion("CoGAPS")),
+    RVersion=R.version.string,
+    platform=R.version$platform,
+    openMP=CoGAPS::compiledWithOpenMPSupport(),
+    buildReport=buildReportText,
+    os=paste(Sys.info()[c("sysname", "release", "machine")], collapse=" ")
+)
+
+modes <- list(
+    list(name="dense_sequential", sparseOptimization=FALSE,
+        asynchronousUpdates=FALSE, nThreads=1),
+    list(name="sparse_sequential", sparseOptimization=TRUE,
+        asynchronousUpdates=FALSE, nThreads=1),
+    list(name="dense_async_one_thread", sparseOptimization=FALSE,
+        asynchronousUpdates=TRUE, nThreads=1),
+    list(name="sparse_async_one_thread", sparseOptimization=TRUE,
+        asynchronousUpdates=TRUE, nThreads=1),
+    list(name="dense_async_two_threads", sparseOptimization=FALSE,
+        asynchronousUpdates=TRUE, nThreads=2),
+    list(name="sparse_async_two_threads", sparseOptimization=TRUE,
+        asynchronousUpdates=TRUE, nThreads=2)
+)
+
+rows <- list()
+for (repeatIndex in seq_len(opts$repeats))
+{
+    for (mode in modes)
+    {
+        fingerprint <- runMode(
+            data=data,
+            opts=opts,
+            modeName=mode$name,
+            sparseOptimization=mode$sparseOptimization,
+            asynchronousUpdates=mode$asynchronousUpdates,
+            nThreads=mode$nThreads,
+            repeatIndex=repeatIndex
+        )
+        rows[[length(rows) + 1]] <- c(metadata, fingerprint)
+    }
+}
+
+out <- as.data.frame(do.call(rbind, rows), stringsAsFactors=FALSE)
+write.table(out, file=opts$out, quote=TRUE, sep="\t", row.names=FALSE)
+cat("wrote compiler reproducibility fingerprint to", opts$out, "\n")

--- a/man/CoGAPS.Rd
+++ b/man/CoGAPS.Rd
@@ -18,7 +18,7 @@ CoGAPS(
   transposeData = FALSE,
   BPPARAM = NULL,
   workerID = 1,
-  asynchronousUpdates = TRUE,
+  asynchronousUpdates = FALSE,
   nSnapshots = 0,
   snapshotPhase = "sampling",
   ...

--- a/src/GapsParameters.cpp
+++ b/src/GapsParameters.cpp
@@ -7,6 +7,7 @@
 void GapsParameters::print() const
 {
     gaps_printf("\n---- C++ Parameters ----\n\n");
+    // Print boolean parameters as TRUE/FALSE strings for readable run logs.
     gaps_printf("transposeData: %s\n", transposeData ? "TRUE" : "FALSE");
     gaps_printf("nGenes: %d\n", nGenes);
     gaps_printf("nSamples: %d\n", nSamples);
@@ -53,6 +54,7 @@ GapsParameters::GapsParameters(){}
 void GapsParameters::calculateDataDimensions(const std::string &file)
 {
     FileParser fp(file);
+    // Respect the requested data orientation when deriving gene and sample counts.
     nGenes = transposeData ? fp.nCol() : fp.nRow();
     nSamples = transposeData ? fp.nRow() : fp.nCol();
     if (subsetData && subsetGenes)
@@ -67,6 +69,7 @@ void GapsParameters::calculateDataDimensions(const std::string &file)
 
 void GapsParameters::calculateDataDimensions(const Matrix &mat)
 {
+    // Respect the requested data orientation when deriving gene and sample counts.
     nGenes = transposeData ? mat.nCol() : mat.nRow();
     nSamples = transposeData ? mat.nRow() : mat.nCol();
     if (subsetData && subsetGenes)

--- a/src/GapsParameters.cpp
+++ b/src/GapsParameters.cpp
@@ -7,7 +7,7 @@
 void GapsParameters::print() const
 {
     gaps_printf("\n---- C++ Parameters ----\n\n");
-    // Print boolean parameters as TRUE/FALSE strings for readable run logs.
+    // [AI-generated] Print boolean parameters as TRUE/FALSE strings for readable run logs.
     gaps_printf("transposeData: %s\n", transposeData ? "TRUE" : "FALSE");
     gaps_printf("nGenes: %d\n", nGenes);
     gaps_printf("nSamples: %d\n", nSamples);
@@ -54,7 +54,7 @@ GapsParameters::GapsParameters(){}
 void GapsParameters::calculateDataDimensions(const std::string &file)
 {
     FileParser fp(file);
-    // Respect the requested data orientation when deriving gene and sample counts.
+    // [AI-generated] Respect the requested data orientation when deriving gene and sample counts.
     nGenes = transposeData ? fp.nCol() : fp.nRow();
     nSamples = transposeData ? fp.nRow() : fp.nCol();
     if (subsetData && subsetGenes)
@@ -69,7 +69,7 @@ void GapsParameters::calculateDataDimensions(const std::string &file)
 
 void GapsParameters::calculateDataDimensions(const Matrix &mat)
 {
-    // Respect the requested data orientation when deriving gene and sample counts.
+    // [AI-generated] Respect the requested data orientation when deriving gene and sample counts.
     nGenes = transposeData ? mat.nCol() : mat.nRow();
     nSamples = transposeData ? mat.nRow() : mat.nCol();
     if (subsetData && subsetGenes)

--- a/src/GapsStatistics.cpp
+++ b/src/GapsStatistics.cpp
@@ -112,6 +112,7 @@ float GapsStatistics::meanChiSq(const SparseNormalModel &model) const
 
 Matrix GapsStatistics::pumpMatrix() const
 {
+    // Avoid division by zero before any pump samples have been accumulated.
     float denom = mPumpUpdates != 0 ? static_cast<float>(mPumpUpdates) : 1.f;
     return mPumpMatrix / denom;
 }
@@ -148,16 +149,19 @@ std::vector<float> GapsStatistics::chisqHistory() const
 
 std::vector<unsigned> GapsStatistics::atomHistory(char m) const
 {
+    // Select the stored atom-count history for the requested factor matrix.
     return m == 'A' ? mAtomHistoryA : mAtomHistoryP;
 }
 
 const std::vector<Matrix>& GapsStatistics::getEquilibrationSnapshots(char whichMatrix) const
 {
+    // Select equilibration snapshots for the requested factor matrix.
     return (whichMatrix == 'A') ? mEquilibrationSnapshotsA : mEquilibrationSnapshotsP;
 }
 
 const std::vector<Matrix>& GapsStatistics::getSamplingSnapshots(char whichMatrix) const
 {
+    // Select sampling snapshots for the requested factor matrix.
     return (whichMatrix == 'A') ? mSamplingSnapshotsA : mSamplingSnapshotsP;
 }
 

--- a/src/GapsStatistics.cpp
+++ b/src/GapsStatistics.cpp
@@ -112,7 +112,7 @@ float GapsStatistics::meanChiSq(const SparseNormalModel &model) const
 
 Matrix GapsStatistics::pumpMatrix() const
 {
-    // Avoid division by zero before any pump samples have been accumulated.
+    // [AI-generated] Avoid division by zero before any pump samples have been accumulated.
     float denom = mPumpUpdates != 0 ? static_cast<float>(mPumpUpdates) : 1.f;
     return mPumpMatrix / denom;
 }
@@ -149,19 +149,19 @@ std::vector<float> GapsStatistics::chisqHistory() const
 
 std::vector<unsigned> GapsStatistics::atomHistory(char m) const
 {
-    // Select the stored atom-count history for the requested factor matrix.
+    // [AI-generated] Select the stored atom-count history for the requested factor matrix.
     return m == 'A' ? mAtomHistoryA : mAtomHistoryP;
 }
 
 const std::vector<Matrix>& GapsStatistics::getEquilibrationSnapshots(char whichMatrix) const
 {
-    // Select equilibration snapshots for the requested factor matrix.
+    // [AI-generated] Select equilibration snapshots for the requested factor matrix.
     return (whichMatrix == 'A') ? mEquilibrationSnapshotsA : mEquilibrationSnapshotsP;
 }
 
 const std::vector<Matrix>& GapsStatistics::getSamplingSnapshots(char whichMatrix) const
 {
-    // Select sampling snapshots for the requested factor matrix.
+    // [AI-generated] Select sampling snapshots for the requested factor matrix.
     return (whichMatrix == 'A') ? mSamplingSnapshotsA : mSamplingSnapshotsP;
 }
 
@@ -178,4 +178,3 @@ Archive& operator>>(Archive &ar, GapsStatistics &stat)
         >> stat.mPStdMatrix >> stat.mStatUpdates >> stat.mNumPatterns;
     return ar;
 }
-

--- a/src/GapsStatistics.h
+++ b/src/GapsStatistics.h
@@ -135,7 +135,7 @@ void GapsStatistics::update(const DataModel &AModel, const DataModel &PModel)
     for (unsigned j = 0; j < mNumPatterns; ++j)
     {
         float norm = gaps::max(PModel.mMatrix.getCol(j));
-        // If a pattern has zero P mass, use a neutral scale factor to avoid
+        // [AI-generated] If a pattern has zero P mass, use a neutral scale factor to avoid
         // dividing by zero while leaving the A/P contribution unchanged.
         norm = (norm == 0.f) ? 1.f : norm;
         Vector quot(PModel.mMatrix.getCol(j) / norm);

--- a/src/GapsStatistics.h
+++ b/src/GapsStatistics.h
@@ -135,6 +135,8 @@ void GapsStatistics::update(const DataModel &AModel, const DataModel &PModel)
     for (unsigned j = 0; j < mNumPatterns; ++j)
     {
         float norm = gaps::max(PModel.mMatrix.getCol(j));
+        // If a pattern has zero P mass, use a neutral scale factor to avoid
+        // dividing by zero while leaving the A/P contribution unchanged.
         norm = (norm == 0.f) ? 1.f : norm;
         Vector quot(PModel.mMatrix.getCol(j) / norm);
         mPMeanMatrix.getCol(j) += quot;

--- a/src/atomic/AtomicDomain.cpp
+++ b/src/atomic/AtomicDomain.cpp
@@ -33,7 +33,7 @@ AtomNeighborhood AtomicDomain::randomAtomWithNeighbors(GapsRng *rng)
     GAPS_ASSERT(size() > 0);
     unsigned index = rng->uniform32(0, mAtoms.size() - 1);
     Atom *center = &(mAtoms[index]);
-    // Build the neighborhood used by move/exchange proposals; edge atoms have
+    // [AI-generated] Build the neighborhood used by move/exchange proposals; edge atoms have
     // a missing neighbor on one side of the ordered atomic domain.
     Atom *left = center->hasLeft() ? &(mAtoms[center->leftIndex()]) : NULL;
     Atom *right = center->hasRight() ? &(mAtoms[center->rightIndex()]) : NULL;
@@ -114,7 +114,7 @@ void AtomicDomain::erase(Atom *atom)
 
 void AtomicDomain::move(Atom *atom, uint64_t newPos)
 {
-    // Validate the move stays between neighboring atoms; domain endpoints stand
+    // [AI-generated] Validate the move stays between neighboring atoms; domain endpoints stand
     // in for missing neighbors at the edges.
     GAPS_ASSERT(newPos > (atom->hasLeft() ? mAtoms[atom->leftIndex()].pos() : 0));
     GAPS_ASSERT(newPos < (atom->hasRight() ? mAtoms[atom->rightIndex()].pos() : mDomainLength));

--- a/src/atomic/AtomicDomain.cpp
+++ b/src/atomic/AtomicDomain.cpp
@@ -33,6 +33,8 @@ AtomNeighborhood AtomicDomain::randomAtomWithNeighbors(GapsRng *rng)
     GAPS_ASSERT(size() > 0);
     unsigned index = rng->uniform32(0, mAtoms.size() - 1);
     Atom *center = &(mAtoms[index]);
+    // Build the neighborhood used by move/exchange proposals; edge atoms have
+    // a missing neighbor on one side of the ordered atomic domain.
     Atom *left = center->hasLeft() ? &(mAtoms[center->leftIndex()]) : NULL;
     Atom *right = center->hasRight() ? &(mAtoms[center->rightIndex()]) : NULL;
     return AtomNeighborhood(left, center, right);
@@ -112,6 +114,8 @@ void AtomicDomain::erase(Atom *atom)
 
 void AtomicDomain::move(Atom *atom, uint64_t newPos)
 {
+    // Validate the move stays between neighboring atoms; domain endpoints stand
+    // in for missing neighbors at the edges.
     GAPS_ASSERT(newPos > (atom->hasLeft() ? mAtoms[atom->leftIndex()].pos() : 0));
     GAPS_ASSERT(newPos < (atom->hasRight() ? mAtoms[atom->rightIndex()].pos() : mDomainLength));
     atom->updatePos(newPos);

--- a/src/atomic/ConcurrentAtomicDomain.cpp
+++ b/src/atomic/ConcurrentAtomicDomain.cpp
@@ -125,7 +125,7 @@ void ConcurrentAtomicDomain::erase(ConcurrentAtom *atom)
 // safe to call concurrently from OpenMP threads
 void ConcurrentAtomicDomain::move(ConcurrentAtom *atom, uint64_t newPos)
 {
-    // Validate the move stays between neighboring atoms; domain endpoints stand
+    // [AI-generated] Validate the move stays between neighboring atoms; domain endpoints stand
     // in for missing neighbors at the edges.
     GAPS_ASSERT(newPos > (atom->hasLeft() ? atom->left()->pos() : 0));
     GAPS_ASSERT(newPos < (atom->hasRight() ? atom->right()->pos() : mDomainLength));

--- a/src/atomic/ConcurrentAtomicDomain.cpp
+++ b/src/atomic/ConcurrentAtomicDomain.cpp
@@ -125,6 +125,8 @@ void ConcurrentAtomicDomain::erase(ConcurrentAtom *atom)
 // safe to call concurrently from OpenMP threads
 void ConcurrentAtomicDomain::move(ConcurrentAtom *atom, uint64_t newPos)
 {
+    // Validate the move stays between neighboring atoms; domain endpoints stand
+    // in for missing neighbors at the edges.
     GAPS_ASSERT(newPos > (atom->hasLeft() ? atom->left()->pos() : 0));
     GAPS_ASSERT(newPos < (atom->hasRight() ? atom->right()->pos() : mDomainLength));
     atom->updatePos(newPos);

--- a/src/atomic/ProposalQueue.cpp
+++ b/src/atomic/ProposalQueue.cpp
@@ -128,6 +128,8 @@ float ProposalQueue::deathProb(double nAtoms) const
 
 bool ProposalQueue::makeProposal(ConcurrentAtomicDomain &domain)
 {
+    // Reuse cached uniforms when a failed proposal is retried; otherwise draw
+    // fresh uniforms for this proposal decision.
     mU1 = mUseCachedRng ? mU1 : mRng.uniform();
     mU2 = mUseCachedRng ? mU2: mRng.uniform();
     mUseCachedRng = false;
@@ -156,6 +158,7 @@ bool ProposalQueue::makeProposal(ConcurrentAtomicDomain &domain)
         }
         return false; // can't determine B/D since range is too wide
     }
+    // Split the upper half of the proposal interval between move and exchange.
     return (mU1 < 0.75f) ? move(domain) : exchange(domain);
 }
 
@@ -212,6 +215,8 @@ bool ProposalQueue::move(ConcurrentAtomicDomain &domain)
     ConcurrentAtomNeighborhood hood = domain.randomAtomWithNeighbors(&(prop.rng));
     prop.atom1 = hood.center;
 
+    // Bound the move by neighboring atom positions; use domain endpoints for
+    // edge atoms.
     uint64_t lbound = hood.hasLeft() ? hood.left->pos() : 0;
     uint64_t rbound = hood.hasRight() ? hood.right->pos() : static_cast<uint64_t>(mDomainLength);
 
@@ -252,6 +257,7 @@ bool ProposalQueue::exchange(ConcurrentAtomicDomain &domain)
     AtomicProposal prop('E', mRandState);
     ConcurrentAtomNeighborhood hood = domain.randomAtomWithNeighbors(&(prop.rng));
     prop.atom1 = hood.center;
+    // Exchange with the right neighbor, wrapping the last atom to the first.
     prop.atom2 = hood.hasRight() ? hood.right : domain.front();
     prop.r1 = (prop.atom1->pos() / mBinLength) / mNumCols;
     prop.c1 = (prop.atom1->pos() / mBinLength) % mNumCols;
@@ -267,6 +273,7 @@ bool ProposalQueue::exchange(ConcurrentAtomicDomain &domain)
     if (prop.r1 == prop.r2 && prop.c1 == prop.c2)
     {
         float newMass = prop.rng.truncGammaUpper(prop.atom1->mass() + prop.atom2->mass(), 1.f / mLambda);
+        // Keep the larger atom as the reference for the mass-transfer direction.
         float delta = (prop.atom1->mass() > prop.atom2->mass()) ? newMass - prop.atom1->mass() : prop.atom2->mass() - newMass;
         if (prop.atom1->mass() + delta > gaps::epsilon && prop.atom2->mass() - delta > gaps::epsilon)
         {

--- a/src/atomic/ProposalQueue.cpp
+++ b/src/atomic/ProposalQueue.cpp
@@ -128,7 +128,7 @@ float ProposalQueue::deathProb(double nAtoms) const
 
 bool ProposalQueue::makeProposal(ConcurrentAtomicDomain &domain)
 {
-    // Reuse cached uniforms when a failed proposal is retried; otherwise draw
+    // [AI-generated] Reuse cached uniforms when a failed proposal is retried; otherwise draw
     // fresh uniforms for this proposal decision.
     mU1 = mUseCachedRng ? mU1 : mRng.uniform();
     mU2 = mUseCachedRng ? mU2: mRng.uniform();
@@ -158,7 +158,7 @@ bool ProposalQueue::makeProposal(ConcurrentAtomicDomain &domain)
         }
         return false; // can't determine B/D since range is too wide
     }
-    // Split the upper half of the proposal interval between move and exchange.
+    // [AI-generated] Split the upper half of the proposal interval between move and exchange.
     return (mU1 < 0.75f) ? move(domain) : exchange(domain);
 }
 
@@ -215,7 +215,7 @@ bool ProposalQueue::move(ConcurrentAtomicDomain &domain)
     ConcurrentAtomNeighborhood hood = domain.randomAtomWithNeighbors(&(prop.rng));
     prop.atom1 = hood.center;
 
-    // Bound the move by neighboring atom positions; use domain endpoints for
+    // [AI-generated] Bound the move by neighboring atom positions; use domain endpoints for
     // edge atoms.
     uint64_t lbound = hood.hasLeft() ? hood.left->pos() : 0;
     uint64_t rbound = hood.hasRight() ? hood.right->pos() : static_cast<uint64_t>(mDomainLength);
@@ -257,7 +257,7 @@ bool ProposalQueue::exchange(ConcurrentAtomicDomain &domain)
     AtomicProposal prop('E', mRandState);
     ConcurrentAtomNeighborhood hood = domain.randomAtomWithNeighbors(&(prop.rng));
     prop.atom1 = hood.center;
-    // Exchange with the right neighbor, wrapping the last atom to the first.
+    // [AI-generated] Exchange with the right neighbor, wrapping the last atom to the first.
     prop.atom2 = hood.hasRight() ? hood.right : domain.front();
     prop.r1 = (prop.atom1->pos() / mBinLength) / mNumCols;
     prop.c1 = (prop.atom1->pos() / mBinLength) % mNumCols;
@@ -273,7 +273,7 @@ bool ProposalQueue::exchange(ConcurrentAtomicDomain &domain)
     if (prop.r1 == prop.r2 && prop.c1 == prop.c2)
     {
         float newMass = prop.rng.truncGammaUpper(prop.atom1->mass() + prop.atom2->mass(), 1.f / mLambda);
-        // Keep the larger atom as the reference for the mass-transfer direction.
+        // [AI-generated] Keep the larger atom as the reference for the mass-transfer direction.
         float delta = (prop.atom1->mass() > prop.atom2->mass()) ? newMass - prop.atom1->mass() : prop.atom2->mass() - newMass;
         if (prop.atom1->mass() + delta > gaps::epsilon && prop.atom2->mass() - delta > gaps::epsilon)
         {

--- a/src/cpp_tests/testHashSets.cpp
+++ b/src/cpp_tests/testHashSets.cpp
@@ -67,10 +67,10 @@ TEST_CASE("Test HashSets.h - SmallPairedHashSetU64","[hashset][pairedU64]")
             hSet.insert(u1, u2);
             REQUIRE(hSet.contains(u1));
             REQUIRE(hSet.contains(u2));
-            // Compute the unsigned distance between two positions without
+            // [AI-generated] Compute the unsigned distance between two positions without
             // assuming which position is larger.
             uint64_t d = u1 > u2 ? u1 - u2 : u2 - u1;
-            // Check an interior point between the two positions, choosing the
+            // [AI-generated] Check an interior point between the two positions, choosing the
             // lower endpoint as the start of the interval.
             REQUIRE(hSet.overlap(u1 > u2 ? u2 + d/2 : u1 + d/2));
         }

--- a/src/cpp_tests/testHashSets.cpp
+++ b/src/cpp_tests/testHashSets.cpp
@@ -67,12 +67,15 @@ TEST_CASE("Test HashSets.h - SmallPairedHashSetU64","[hashset][pairedU64]")
             hSet.insert(u1, u2);
             REQUIRE(hSet.contains(u1));
             REQUIRE(hSet.contains(u2));
+            // Compute the unsigned distance between two positions without
+            // assuming which position is larger.
             uint64_t d = u1 > u2 ? u1 - u2 : u2 - u1;
+            // Check an interior point between the two positions, choosing the
+            // lower endpoint as the start of the interval.
             REQUIRE(hSet.overlap(u1 > u2 ? u2 + d/2 : u1 + d/2));
         }
         hSet.clear();
+
         REQUIRE(hSet.isEmpty());
     }
 }
-
-

--- a/src/cpp_tests/testSamplerHighLevel.cpp
+++ b/src/cpp_tests/testSamplerHighLevel.cpp
@@ -19,6 +19,8 @@ Matrix getDummyData(unsigned nrow, unsigned ncol)
     {
         for (unsigned j = 0; j < data.nCol(); ++j)
         {
+            // Build a simple checkerboard-like test matrix with zeros on
+            // alternating entries.
             data(i,j) = i * j % 2 == 1 ? 0.f : static_cast<float>(i * j);
         }
     }

--- a/src/cpp_tests/testSamplerHighLevel.cpp
+++ b/src/cpp_tests/testSamplerHighLevel.cpp
@@ -19,7 +19,7 @@ Matrix getDummyData(unsigned nrow, unsigned ncol)
     {
         for (unsigned j = 0; j < data.nCol(); ++j)
         {
-            // Build a simple checkerboard-like test matrix with zeros on
+            // [AI-generated] Build a simple checkerboard-like test matrix with zeros on
             // alternating entries.
             data(i,j) = i * j % 2 == 1 ? 0.f : static_cast<float>(i * j);
         }

--- a/src/cpp_tests/testSparseGibbsSampler.cpp
+++ b/src/cpp_tests/testSparseGibbsSampler.cpp
@@ -49,6 +49,8 @@ TEST_CASE("Test SparseGibbsSampler")
         {
             for (unsigned j = 0; j < data.nCol(); ++j)
             {
+                // Generate sparse test data by randomly zeroing about half of
+                // the entries.
                 data(i,j) = rng.uniform32(1,14) * (rng.uniform() < 0.5f ? 0.f : 1.f);
             }
         }
@@ -75,6 +77,8 @@ TEST_CASE("Test SparseGibbsSampler")
         {
             for (unsigned k = 0; k < params.nPatterns; ++k)
             {
+                // Populate matching dense/sparse test matrices with mostly
+                // nonzero values and occasional zeros.
                 float val = rng.uniform(0.f, 10.f) * (rng.uniform() < 0.2f ? 0.f : 1.f);
                 dense_ASampler.mMatrix(i,k) = val;
                 sparse_ASampler.mMatrix.add(i, k, val);
@@ -86,6 +90,8 @@ TEST_CASE("Test SparseGibbsSampler")
         {
             for (unsigned k = 0; k < params.nPatterns; ++k)
             {
+                // Populate matching dense/sparse test matrices with mostly
+                // nonzero values and occasional zeros.
                 float val = rng.uniform(0.f, 10.f) * (rng.uniform() < 0.2f ? 0.f : 1.f);
                 dense_PSampler.mMatrix(j,k) = val;
                 sparse_PSampler.mMatrix.add(j, k, val);

--- a/src/cpp_tests/testSparseGibbsSampler.cpp
+++ b/src/cpp_tests/testSparseGibbsSampler.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Test SparseGibbsSampler")
         {
             for (unsigned j = 0; j < data.nCol(); ++j)
             {
-                // Generate sparse test data by randomly zeroing about half of
+                // [AI-generated] Generate sparse test data by randomly zeroing about half of
                 // the entries.
                 data(i,j) = rng.uniform32(1,14) * (rng.uniform() < 0.5f ? 0.f : 1.f);
             }
@@ -77,7 +77,7 @@ TEST_CASE("Test SparseGibbsSampler")
         {
             for (unsigned k = 0; k < params.nPatterns; ++k)
             {
-                // Populate matching dense/sparse test matrices with mostly
+                // [AI-generated] Populate matching dense/sparse test matrices with mostly
                 // nonzero values and occasional zeros.
                 float val = rng.uniform(0.f, 10.f) * (rng.uniform() < 0.2f ? 0.f : 1.f);
                 dense_ASampler.mMatrix(i,k) = val;
@@ -90,7 +90,7 @@ TEST_CASE("Test SparseGibbsSampler")
         {
             for (unsigned k = 0; k < params.nPatterns; ++k)
             {
-                // Populate matching dense/sparse test matrices with mostly
+                // [AI-generated] Populate matching dense/sparse test matrices with mostly
                 // nonzero values and occasional zeros.
                 float val = rng.uniform(0.f, 10.f) * (rng.uniform() < 0.2f ? 0.f : 1.f);
                 dense_PSampler.mMatrix(j,k) = val;

--- a/src/cpp_tests/testSparseIterator.cpp
+++ b/src/cpp_tests/testSparseIterator.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Test SparseIterator.h - One Dimensional","[sparseiterator][1D]")
         {
             for (unsigned j = 0; j < ref.nCol(); ++j)
             {
-                // Build toy sparse test data by randomly zeroing half of the
+                // [AI-generated] Build toy sparse test data by randomly zeroing half of the
                 // candidate entries.
                 ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
             }
@@ -210,7 +210,7 @@ TEST_CASE("Test SparseIterator.h - Two Dimensional","[sparseiterator][2D]")
         {
             for (unsigned j = 0; j < ref.nCol(); ++j)
             {
-                // Build toy sparse test data by randomly zeroing half of the
+                // [AI-generated] Build toy sparse test data by randomly zeroing half of the
                 // candidate entries.
                 ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
                 hMat.add(i, j, ref(i,j));
@@ -294,7 +294,7 @@ TEST_CASE("Test SparseIterator.h - Three Dimensional","[sparseiterator][3D]")
         {
             for (unsigned j = 0; j < ref.nCol(); ++j)
             {
-                // Build toy sparse test data by randomly zeroing half of the
+                // [AI-generated] Build toy sparse test data by randomly zeroing half of the
                 // candidate entries.
                 ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
                 hMat.add(i, j, ref(i,j));

--- a/src/cpp_tests/testSparseIterator.cpp
+++ b/src/cpp_tests/testSparseIterator.cpp
@@ -43,6 +43,8 @@ TEST_CASE("Test SparseIterator.h - One Dimensional","[sparseiterator][1D]")
         {
             for (unsigned j = 0; j < ref.nCol(); ++j)
             {
+                // Build toy sparse test data by randomly zeroing half of the
+                // candidate entries.
                 ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
             }
         }
@@ -208,6 +210,8 @@ TEST_CASE("Test SparseIterator.h - Two Dimensional","[sparseiterator][2D]")
         {
             for (unsigned j = 0; j < ref.nCol(); ++j)
             {
+                // Build toy sparse test data by randomly zeroing half of the
+                // candidate entries.
                 ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
                 hMat.add(i, j, ref(i,j));
             }
@@ -290,6 +294,8 @@ TEST_CASE("Test SparseIterator.h - Three Dimensional","[sparseiterator][3D]")
         {
             for (unsigned j = 0; j < ref.nCol(); ++j)
             {
+                // Build toy sparse test data by randomly zeroing half of the
+                // candidate entries.
                 ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
                 hMat.add(i, j, ref(i,j));
             }

--- a/src/cpp_tests/testSparseMatrix.cpp
+++ b/src/cpp_tests/testSparseMatrix.cpp
@@ -67,6 +67,8 @@ TEST_CASE("Test Writing/Reading Sparse Matrices from File")
     {
         for (unsigned j = 0; j < ref.nCol(); ++j)
         {
+            // Build toy sparse test data by randomly zeroing half of the
+            // candidate entries.
             ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
         }
     }

--- a/src/cpp_tests/testSparseMatrix.cpp
+++ b/src/cpp_tests/testSparseMatrix.cpp
@@ -67,7 +67,7 @@ TEST_CASE("Test Writing/Reading Sparse Matrices from File")
     {
         for (unsigned j = 0; j < ref.nCol(); ++j)
         {
-            // Build toy sparse test data by randomly zeroing half of the
+            // [AI-generated] Build toy sparse test data by randomly zeroing half of the
             // candidate entries.
             ref(i,j) = (i + j) * (rng.uniform() < 0.5f ? 0.f : 1.f);
         }

--- a/src/data_structures/HashSets.cpp
+++ b/src/data_structures/HashSets.cpp
@@ -73,7 +73,7 @@ SmallPairedHashSetU64::SmallPairedHashSetU64() {}
 
 void SmallPairedHashSetU64::insert(uint64_t a, uint64_t b)
 {
-    // Store position pairs in sorted order so overlap checks are direction-agnostic.
+    // [AI-generated] Store position pairs in sorted order so overlap checks are direction-agnostic.
     mSet.push_back(a < b ? PositionPair(a, b) : PositionPair(b, a));
 }
 

--- a/src/data_structures/HashSets.cpp
+++ b/src/data_structures/HashSets.cpp
@@ -73,6 +73,7 @@ SmallPairedHashSetU64::SmallPairedHashSetU64() {}
 
 void SmallPairedHashSetU64::insert(uint64_t a, uint64_t b)
 {
+    // Store position pairs in sorted order so overlap checks are direction-agnostic.
     mSet.push_back(a < b ? PositionPair(a, b) : PositionPair(b, a));
 }
 

--- a/src/data_structures/HybridVector.cpp
+++ b/src/data_structures/HybridVector.cpp
@@ -88,7 +88,7 @@ bool HybridVector::set(unsigned i, float v)
 float HybridVector::operator[](unsigned i) const
 {
     GAPS_ASSERT(i < mSize);
-    // In sparse mode, zero entries should not have an index flag; nonzero
+    // [AI-generated] In sparse mode, zero entries should not have an index flag; nonzero
     // entries should have the corresponding bit set.
     GAPS_ASSERT((mData[i] == 0.f)
         ? !(mIndexBitFlags[i / 64] & (1ull << (i % 64)))
@@ -131,5 +131,4 @@ Archive& operator>>(Archive &ar, HybridVector &vec)
     }
     return ar;
 }
-
 

--- a/src/data_structures/HybridVector.cpp
+++ b/src/data_structures/HybridVector.cpp
@@ -88,6 +88,8 @@ bool HybridVector::set(unsigned i, float v)
 float HybridVector::operator[](unsigned i) const
 {
     GAPS_ASSERT(i < mSize);
+    // In sparse mode, zero entries should not have an index flag; nonzero
+    // entries should have the corresponding bit set.
     GAPS_ASSERT((mData[i] == 0.f)
         ? !(mIndexBitFlags[i / 64] & (1ull << (i % 64)))
         : (mIndexBitFlags[i / 64] & (1ull << (i % 64)))

--- a/src/data_structures/Matrix.cpp
+++ b/src/data_structures/Matrix.cpp
@@ -40,7 +40,7 @@ std::vector<unsigned> indices)
 
     bool subsetData = !indices.empty();
 
-    // When subsetting, the selected index count determines the active
+    // [AI-generated] When subsetting, the selected index count determines the active
     // dimension; otherwise derive dimensions from the input orientation.
     unsigned nGenes = (subsetData && subsetGenes)
         ? indices.size()
@@ -54,13 +54,13 @@ std::vector<unsigned> indices)
         mCols.push_back(Vector(nGenes));
         for (unsigned i = 0; i < nGenes; ++i)
         {
-            // Map output coordinates back to input rows, using subset indices
+            // [AI-generated] Map output coordinates back to input rows, using subset indices
             // when the subset applies to the row-like axis in the source data.
             unsigned dataRow = (subsetData && (subsetGenes != genesInCols))
                 ? indices[genesInCols ? j : i] - 1
                 : genesInCols ? j : i;
 
-            // Map output coordinates back to input columns, using subset
+            // [AI-generated] Map output coordinates back to input columns, using subset
             // indices when the subset applies to the column-like source axis.
             unsigned dataCol = (subsetData && (subsetGenes == genesInCols))
                 ? indices[genesInCols ? i : j] - 1
@@ -90,7 +90,7 @@ std::vector<unsigned> indices)
 
     // calculate the number of rows and columns
     bool subsetData = !indices.empty();
-    // When subsetting, the selected index count determines the active
+    // [AI-generated] When subsetting, the selected index count determines the active
     // dimension; otherwise derive dimensions from the file orientation.
     mNumRows = (subsetData && subsetGenes) // nGenes
         ? indices.size()
@@ -111,7 +111,7 @@ std::vector<unsigned> indices)
         while (fp.hasNext())
         {
             MatrixElement e(fp.getNext());
-            // Convert file row/column coordinates to internal matrix
+            // [AI-generated] Convert file row/column coordinates to internal matrix
             // coordinates based on whether genes are stored in columns.
             unsigned row = genesInCols ? e.col : e.row;
             unsigned col = genesInCols ? e.row : e.col;
@@ -124,7 +124,7 @@ std::vector<unsigned> indices)
         while (fp.hasNext())
         {
             MatrixElement e(fp.getNext());
-            // Pick the source coordinate that corresponds to the subsetted axis.
+            // [AI-generated] Pick the source coordinate that corresponds to the subsetted axis.
             unsigned searchIndex = 1 + ((subsetGenes != genesInCols) ? e.row : e.col);
             std::vector<unsigned>::iterator pos = 
                 std::lower_bound(indices.begin(), indices.end(), searchIndex);
@@ -132,7 +132,7 @@ std::vector<unsigned> indices)
             // this index is included in the subset
             if (pos != indices.end() && *pos == searchIndex)
             {
-                // Use the subset position for the subsetted dimension and the
+                // [AI-generated] Use the subset position for the subsetted dimension and the
                 // file coordinate for the other dimension.
                 unsigned row = subsetGenes
                     ? std::distance(indices.begin(), pos)

--- a/src/data_structures/Matrix.cpp
+++ b/src/data_structures/Matrix.cpp
@@ -40,6 +40,8 @@ std::vector<unsigned> indices)
 
     bool subsetData = !indices.empty();
 
+    // When subsetting, the selected index count determines the active
+    // dimension; otherwise derive dimensions from the input orientation.
     unsigned nGenes = (subsetData && subsetGenes)
         ? indices.size()
         : genesInCols ? mat.nCol() : mat.nRow();
@@ -52,10 +54,14 @@ std::vector<unsigned> indices)
         mCols.push_back(Vector(nGenes));
         for (unsigned i = 0; i < nGenes; ++i)
         {
+            // Map output coordinates back to input rows, using subset indices
+            // when the subset applies to the row-like axis in the source data.
             unsigned dataRow = (subsetData && (subsetGenes != genesInCols))
                 ? indices[genesInCols ? j : i] - 1
                 : genesInCols ? j : i;
 
+            // Map output coordinates back to input columns, using subset
+            // indices when the subset applies to the column-like source axis.
             unsigned dataCol = (subsetData && (subsetGenes == genesInCols))
                 ? indices[genesInCols ? i : j] - 1
                 : genesInCols ? i : j;
@@ -84,6 +90,8 @@ std::vector<unsigned> indices)
 
     // calculate the number of rows and columns
     bool subsetData = !indices.empty();
+    // When subsetting, the selected index count determines the active
+    // dimension; otherwise derive dimensions from the file orientation.
     mNumRows = (subsetData && subsetGenes) // nGenes
         ? indices.size()
         : genesInCols ? fp.nCol() : fp.nRow();
@@ -103,6 +111,8 @@ std::vector<unsigned> indices)
         while (fp.hasNext())
         {
             MatrixElement e(fp.getNext());
+            // Convert file row/column coordinates to internal matrix
+            // coordinates based on whether genes are stored in columns.
             unsigned row = genesInCols ? e.col : e.row;
             unsigned col = genesInCols ? e.row : e.col;
             this->operator()(row, col) = e.value;
@@ -114,6 +124,7 @@ std::vector<unsigned> indices)
         while (fp.hasNext())
         {
             MatrixElement e(fp.getNext());
+            // Pick the source coordinate that corresponds to the subsetted axis.
             unsigned searchIndex = 1 + ((subsetGenes != genesInCols) ? e.row : e.col);
             std::vector<unsigned>::iterator pos = 
                 std::lower_bound(indices.begin(), indices.end(), searchIndex);
@@ -121,6 +132,8 @@ std::vector<unsigned> indices)
             // this index is included in the subset
             if (pos != indices.end() && *pos == searchIndex)
             {
+                // Use the subset position for the subsetted dimension and the
+                // file coordinate for the other dimension.
                 unsigned row = subsetGenes
                     ? std::distance(indices.begin(), pos)
                     : genesInCols ? e.col : e.row;

--- a/src/data_structures/SparseMatrix.cpp
+++ b/src/data_structures/SparseMatrix.cpp
@@ -21,7 +21,7 @@ bool subsetGenes, std::vector<unsigned> indices)
 
     bool subsetData = !indices.empty();
 
-    // When subsetting, the selected index count determines the active
+    // [AI-generated] When subsetting, the selected index count determines the active
     // dimension; otherwise derive dimensions from the input orientation.
     unsigned nGenes = (subsetData && subsetGenes)
         ? indices.size()
@@ -35,13 +35,13 @@ bool subsetGenes, std::vector<unsigned> indices)
         std::vector<float> values;
         for (unsigned i = 0; i < nGenes; ++i)
         {
-            // Map output coordinates back to input rows, using subset indices
+            // [AI-generated] Map output coordinates back to input rows, using subset indices
             // when the subset applies to the row-like axis in the source data.
             unsigned dataRow = (subsetData && (subsetGenes != genesInCols))
                 ? indices[genesInCols ? j : i] - 1
                 : genesInCols ? j : i;
 
-            // Map output coordinates back to input columns, using subset
+            // [AI-generated] Map output coordinates back to input columns, using subset
             // indices when the subset applies to the column-like source axis.
             unsigned dataCol = (subsetData && (subsetGenes == genesInCols))
                 ? indices[genesInCols ? i : j] - 1
@@ -71,7 +71,7 @@ bool subsetGenes, std::vector<unsigned> indices)
 
     // calculate the number of rows and columns
     bool subsetData = !indices.empty();
-    // When subsetting, the selected index count determines the active
+    // [AI-generated] When subsetting, the selected index count determines the active
     // dimension; otherwise derive dimensions from the file orientation.
     mNumRows = (subsetData && subsetGenes) // nGenes
         ? indices.size()
@@ -92,7 +92,7 @@ bool subsetGenes, std::vector<unsigned> indices)
         while (fp.hasNext())
         {
             MatrixElement e(fp.getNext());
-            // Convert file row/column coordinates to internal matrix
+            // [AI-generated] Convert file row/column coordinates to internal matrix
             // coordinates based on whether genes are stored in columns.
             unsigned row = genesInCols ? e.col : e.row;
             unsigned col = genesInCols ? e.row : e.col;
@@ -110,7 +110,7 @@ bool subsetGenes, std::vector<unsigned> indices)
             MatrixElement e(fp.getNext());
             if (e.value > 0.f)
             {
-                // Pick the source coordinate that corresponds to the subsetted axis.
+                // [AI-generated] Pick the source coordinate that corresponds to the subsetted axis.
                 unsigned searchIndex = 1 + ((subsetGenes != genesInCols) ? e.row : e.col);
                 std::vector<unsigned>::iterator pos = 
                     std::lower_bound(indices.begin(), indices.end(), searchIndex);
@@ -118,7 +118,7 @@ bool subsetGenes, std::vector<unsigned> indices)
                 // this index is included in the subset
                 if (pos != indices.end() && *pos == searchIndex)
                 {
-                    // Use the subset position for the subsetted dimension and
+                    // [AI-generated] Use the subset position for the subsetted dimension and
                     // the file coordinate for the other dimension.
                     unsigned row = subsetGenes
                         ? std::distance(indices.begin(), pos)

--- a/src/data_structures/SparseMatrix.cpp
+++ b/src/data_structures/SparseMatrix.cpp
@@ -21,6 +21,8 @@ bool subsetGenes, std::vector<unsigned> indices)
 
     bool subsetData = !indices.empty();
 
+    // When subsetting, the selected index count determines the active
+    // dimension; otherwise derive dimensions from the input orientation.
     unsigned nGenes = (subsetData && subsetGenes)
         ? indices.size()
         : genesInCols ? mat.nCol() : mat.nRow();
@@ -33,10 +35,14 @@ bool subsetGenes, std::vector<unsigned> indices)
         std::vector<float> values;
         for (unsigned i = 0; i < nGenes; ++i)
         {
+            // Map output coordinates back to input rows, using subset indices
+            // when the subset applies to the row-like axis in the source data.
             unsigned dataRow = (subsetData && (subsetGenes != genesInCols))
                 ? indices[genesInCols ? j : i] - 1
                 : genesInCols ? j : i;
 
+            // Map output coordinates back to input columns, using subset
+            // indices when the subset applies to the column-like source axis.
             unsigned dataCol = (subsetData && (subsetGenes == genesInCols))
                 ? indices[genesInCols ? i : j] - 1
                 : genesInCols ? i : j;
@@ -65,6 +71,8 @@ bool subsetGenes, std::vector<unsigned> indices)
 
     // calculate the number of rows and columns
     bool subsetData = !indices.empty();
+    // When subsetting, the selected index count determines the active
+    // dimension; otherwise derive dimensions from the file orientation.
     mNumRows = (subsetData && subsetGenes) // nGenes
         ? indices.size()
         : genesInCols ? fp.nCol() : fp.nRow();
@@ -84,6 +92,8 @@ bool subsetGenes, std::vector<unsigned> indices)
         while (fp.hasNext())
         {
             MatrixElement e(fp.getNext());
+            // Convert file row/column coordinates to internal matrix
+            // coordinates based on whether genes are stored in columns.
             unsigned row = genesInCols ? e.col : e.row;
             unsigned col = genesInCols ? e.row : e.col;
             if (e.value > 0.f)
@@ -100,6 +110,7 @@ bool subsetGenes, std::vector<unsigned> indices)
             MatrixElement e(fp.getNext());
             if (e.value > 0.f)
             {
+                // Pick the source coordinate that corresponds to the subsetted axis.
                 unsigned searchIndex = 1 + ((subsetGenes != genesInCols) ? e.row : e.col);
                 std::vector<unsigned>::iterator pos = 
                     std::lower_bound(indices.begin(), indices.end(), searchIndex);
@@ -107,6 +118,8 @@ bool subsetGenes, std::vector<unsigned> indices)
                 // this index is included in the subset
                 if (pos != indices.end() && *pos == searchIndex)
                 {
+                    // Use the subset position for the subsetted dimension and
+                    // the file coordinate for the other dimension.
                     unsigned row = subsetGenes
                         ? std::distance(indices.begin(), pos)
                         : genesInCols ? e.col : e.row;

--- a/src/file_parser/CharacterDelimitedParser.cpp
+++ b/src/file_parser/CharacterDelimitedParser.cpp
@@ -10,12 +10,14 @@ static const std::string trimChars = " \r\n\"";
 static std::string ltrim(const std::string &s)
 {
     std::size_t start = s.find_first_not_of(trimChars);
+    // If there is no non-whitespace character, return an empty trimmed string.
     return (start == std::string::npos) ? "" : s.substr(start);
 }
 
 static std::string rtrim(const std::string &s)
 {
     std::size_t end = s.find_last_not_of(trimChars);
+    // If there is no trailing non-whitespace character, return an empty string.
     return (end == std::string::npos) ? "" : s.substr(0, end + 1);
 }
 

--- a/src/file_parser/CharacterDelimitedParser.cpp
+++ b/src/file_parser/CharacterDelimitedParser.cpp
@@ -10,14 +10,14 @@ static const std::string trimChars = " \r\n\"";
 static std::string ltrim(const std::string &s)
 {
     std::size_t start = s.find_first_not_of(trimChars);
-    // If there is no non-whitespace character, return an empty trimmed string.
+    // [AI-generated] If there is no non-whitespace character, return an empty trimmed string.
     return (start == std::string::npos) ? "" : s.substr(start);
 }
 
 static std::string rtrim(const std::string &s)
 {
     std::size_t end = s.find_last_not_of(trimChars);
-    // If there is no trailing non-whitespace character, return an empty string.
+    // [AI-generated] If there is no trailing non-whitespace character, return an empty string.
     return (end == std::string::npos) ? "" : s.substr(0, end + 1);
 }
 

--- a/src/gibbs_sampler/AsynchronousGibbsSampler.h
+++ b/src/gibbs_sampler/AsynchronousGibbsSampler.h
@@ -126,7 +126,7 @@ void AsynchronousGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nThre
 template <class DataModel>
 void AsynchronousGibbsSampler<DataModel>::birth(const AtomicProposal &prop)
 {
-    // If the conditional Gibbs distribution is defined, sample from it;
+    // [AI-generated] If the conditional Gibbs distribution is defined, sample from it;
     // otherwise use the exponential prior so the birth proposal remains valid.
     OptionalFloat mass = DataModel::canUseGibbs(prop.c1)
         ? DataModel::sampleBirth(prop.r1, prop.c1, &(prop.rng))
@@ -261,7 +261,7 @@ float AsynchronousGibbsSampler<DataModel>::maximumDrift() const
             float actual = DataModel::mMatrix(row, col);
             //float drift = (actual > 1.f) ? std::abs(actual - mass) / actual : actual;
             float drift = std::abs(actual - mass);
-            // Track the largest mismatch between atomic and matrix mass.
+            // [AI-generated] Track the largest mismatch between atomic and matrix mass.
             maxDrift = (drift > maxDrift) ? drift : maxDrift;
             mass = atom->mass();
             row = newRow;

--- a/src/gibbs_sampler/AsynchronousGibbsSampler.h
+++ b/src/gibbs_sampler/AsynchronousGibbsSampler.h
@@ -126,7 +126,8 @@ void AsynchronousGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nThre
 template <class DataModel>
 void AsynchronousGibbsSampler<DataModel>::birth(const AtomicProposal &prop)
 {
-    // try to get mass using gibbs, resort to exponential if needed
+    // If the conditional Gibbs distribution is defined, sample from it;
+    // otherwise use the exponential prior so the birth proposal remains valid.
     OptionalFloat mass = DataModel::canUseGibbs(prop.c1)
         ? DataModel::sampleBirth(prop.r1, prop.c1, &(prop.rng))
         : prop.rng.exponential(DataModel::lambda());
@@ -260,6 +261,7 @@ float AsynchronousGibbsSampler<DataModel>::maximumDrift() const
             float actual = DataModel::mMatrix(row, col);
             //float drift = (actual > 1.f) ? std::abs(actual - mass) / actual : actual;
             float drift = std::abs(actual - mass);
+            // Track the largest mismatch between atomic and matrix mass.
             maxDrift = (drift > maxDrift) ? drift : maxDrift;
             mass = atom->mass();
             row = newRow;

--- a/src/gibbs_sampler/SingleThreadedGibbsSampler.h
+++ b/src/gibbs_sampler/SingleThreadedGibbsSampler.h
@@ -110,8 +110,11 @@ char SingleThreadedGibbsSampler<DataModel>::getUpdateType() const
         double nAtoms = static_cast<double>(mDomain.size());
         double numer = nAtoms * mDomainLength;
         float deathProb = numer / (numer + mAlpha * mNumBins * (mDomainLength - nAtoms));
+        // Within the birth/death branch, choose death with probability implied
+        // by the atom-count prior; otherwise propose birth.
         return mRng.uniform() < deathProb ? 'D' : 'B';
     }
+    // Split the remaining proposal interval between move and exchange.
     return u1 < 0.75f ? 'M' : 'E';
 }
 
@@ -209,6 +212,8 @@ void SingleThreadedGibbsSampler<DataModel>::move()
     // Select an atom and its left/right neighbors to preserve atomic ordering.
     AtomNeighborhoodType hood = mDomain.randomAtomWithNeighbors(&mRng);
     AtomType *atom = hood.center;
+    // Bound the move by neighboring atom positions; use domain endpoints for
+    // edge atoms.
     uint64_t lbound = hood.hasLeft() ? hood.left->pos() : 0;
     uint64_t rbound = hood.hasRight() ? hood.right->pos() :
         static_cast<uint64_t>(mDomainLength);
@@ -247,6 +252,7 @@ void SingleThreadedGibbsSampler<DataModel>::exchange()
     // Select an atom and its right neighbor, wrapping at the end of the domain.
     AtomNeighborhoodType hood = mDomain.randomAtomWithNeighbors(&mRng);
     AtomType *atom1 = hood.center;
+    // Exchange with the right neighbor, wrapping the last atom to the first.
     AtomType *atom2 = hood.hasRight() ? hood.right : mDomain.front();
 
     // Map both atom positions to matrix indices.

--- a/src/gibbs_sampler/SingleThreadedGibbsSampler.h
+++ b/src/gibbs_sampler/SingleThreadedGibbsSampler.h
@@ -94,7 +94,7 @@ float SingleThreadedGibbsSampler<DataModel>::getAverageQueueLength() const
 template <class DataModel>
 char SingleThreadedGibbsSampler<DataModel>::getUpdateType() const
 {
-    // Move and exchange require existing atoms and neighboring atom positions.
+    // [AI-generated] Move and exchange require existing atoms and neighboring atom positions.
     // With fewer than two atoms, force birth so early model-fitting states do
     // not create degenerate proposals with undefined conditional distributions.
     if (mDomain.size() < 2)
@@ -102,7 +102,7 @@ char SingleThreadedGibbsSampler<DataModel>::getUpdateType() const
         return 'B'; // always birth when no atoms exist
     }
 
-    // Choose among the four reversible-jump moves used by the atomic prior.
+    // [AI-generated] Choose among the four reversible-jump moves used by the atomic prior.
     // Birth/death change the number of atoms; move/exchange preserve it.
     float u1 = mRng.uniform();
     if (u1 < 0.5f)
@@ -110,18 +110,18 @@ char SingleThreadedGibbsSampler<DataModel>::getUpdateType() const
         double nAtoms = static_cast<double>(mDomain.size());
         double numer = nAtoms * mDomainLength;
         float deathProb = numer / (numer + mAlpha * mNumBins * (mDomainLength - nAtoms));
-        // Within the birth/death branch, choose death with probability implied
+        // [AI-generated] Within the birth/death branch, choose death with probability implied
         // by the atom-count prior; otherwise propose birth.
         return mRng.uniform() < deathProb ? 'D' : 'B';
     }
-    // Split the remaining proposal interval between move and exchange.
+    // [AI-generated] Split the remaining proposal interval between move and exchange.
     return u1 < 0.75f ? 'M' : 'E';
 }
 
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nThreads) // NOLINT
 {
-    // Sequential sampler path: each proposal is generated, evaluated, and
+    // [AI-generated] Sequential sampler path: each proposal is generated, evaluated, and
     // applied before the next proposal is drawn.
     for (unsigned i = 0; i < nSteps; ++i)
     {
@@ -135,7 +135,7 @@ void SingleThreadedGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nTh
     }
 }
 
-// Birth adds an atom at a random free position in the atomic domain. Early in
+// [AI-generated] Birth adds an atom at a random free position in the atomic domain. Early in
 // model fitting, the conditional Gibbs distribution may be undefined because
 // its variance term would require division by zero. In those cases, the atom
 // mass is sampled from the exponential prior so the full proposal can still be
@@ -143,18 +143,18 @@ void SingleThreadedGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nTh
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::birth()
 {
-    // Map the atomic position to the matrix row and pattern column it updates.
+    // [AI-generated] Map the atomic position to the matrix row and pattern column it updates.
     uint64_t pos = mDomain.randomFreePosition(&mRng);
     unsigned row = (pos / mBinLength) / mNumPatterns;
     unsigned col = (pos / mBinLength) % mNumPatterns;
 
-    // Sample mass using Gibbs when the conditional distribution is defined;
+    // [AI-generated] Sample mass using Gibbs when the conditional distribution is defined;
     // fall back to the prior when the conditional variance would be degenerate.
     OptionalFloat mass = DataModel::canUseGibbs(col)
         ? DataModel::sampleBirth(row, col, &mRng)
         : mRng.exponential(DataModel::lambda());
 
-    // Accept the birth when the proposed mass is valid and nonzero.
+    // [AI-generated] Accept the birth when the proposed mass is valid and nonzero.
     if (mass.hasValue() && mass.value() > gaps::epsilon)
     {
         mDomain.insert(pos, mass.value());
@@ -162,18 +162,18 @@ void SingleThreadedGibbsSampler<DataModel>::birth()
     }
 }
 
-// Death removes an atom by first subtracting its mass from the matrix, then
+// [AI-generated] Death removes an atom by first subtracting its mass from the matrix, then
 // attempting a rebirth at the same matrix element. When the conditional Gibbs
 // distribution is defined, it proposes the rebirth mass; otherwise the original
 // mass is retained so the full death/rebirth proposal can still be evaluated.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::death()
 {
-    // Select an atom and map its position to the matrix row and pattern column.
+    // [AI-generated] Select an atom and map its position to the matrix row and pattern column.
     AtomType *atom = mDomain.randomAtom(&mRng);
     unsigned row = (atom->pos() / mBinLength) / mNumPatterns;
     unsigned col = (atom->pos() / mBinLength) % mNumPatterns;
-    // Determine the mass to attempt rebirth with.
+    // [AI-generated] Determine the mass to attempt rebirth with.
     float rebirthMass = atom->mass(); // default rebirth mass == no change to atom
     AlphaParameters alpha = DataModel::alphaParametersWithChange(row, col, -1.f * atom->mass())
         * DataModel::annealingTemp();
@@ -186,7 +186,7 @@ void SingleThreadedGibbsSampler<DataModel>::death()
             rebirthMass = gMass.value();
         }
     }
-    // Handle accept/reject of the rebirth step.
+    // [AI-generated] Handle accept/reject of the rebirth step.
     float deltaLL = rebirthMass * (alpha.s_mu - alpha.s * rebirthMass / 2.f);
     if (std::log(mRng.uniform()) < deltaLL) // accept
     {
@@ -203,22 +203,22 @@ void SingleThreadedGibbsSampler<DataModel>::death()
     }
 }
 
-// Move shifts an existing atom to a new position between its neighboring atoms.
+// [AI-generated] Move shifts an existing atom to a new position between its neighboring atoms.
 // If the move crosses matrix elements, accept/reject is based on the resulting
 // change in likelihood.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::move()
 {
-    // Select an atom and its left/right neighbors to preserve atomic ordering.
+    // [AI-generated] Select an atom and its left/right neighbors to preserve atomic ordering.
     AtomNeighborhoodType hood = mDomain.randomAtomWithNeighbors(&mRng);
     AtomType *atom = hood.center;
-    // Bound the move by neighboring atom positions; use domain endpoints for
+    // [AI-generated] Bound the move by neighboring atom positions; use domain endpoints for
     // edge atoms.
     uint64_t lbound = hood.hasLeft() ? hood.left->pos() : 0;
     uint64_t rbound = hood.hasRight() ? hood.right->pos() :
         static_cast<uint64_t>(mDomainLength);
 
-    // Select the new atomic position and map old/new positions to matrix indices.
+    // [AI-generated] Select the new atomic position and map old/new positions to matrix indices.
     uint64_t pos = mRng.uniform64(lbound + 1, rbound - 1);
     unsigned r1 = (atom->pos() / mBinLength) / mNumPatterns;
     unsigned c1 = (atom->pos() / mBinLength) % mNumPatterns;
@@ -232,7 +232,7 @@ void SingleThreadedGibbsSampler<DataModel>::move()
         return;
     }
     
-    // Conditionally accept moves that change matrix elements.
+    // [AI-generated] Conditionally accept moves that change matrix elements.
     float deltaLL = DataModel::deltaLogLikelihood(r1, c1, r2, c2, atom->mass());
     if (std::log(mRng.uniform()) < deltaLL)
     {
@@ -242,26 +242,26 @@ void SingleThreadedGibbsSampler<DataModel>::move()
     }
 }
 
-// Exchange transfers mass between neighboring atoms. When the two atoms affect
+// [AI-generated] Exchange transfers mass between neighboring atoms. When the two atoms affect
 // different matrix elements and the conditional Gibbs distribution is defined,
 // that distribution proposes the amount of mass to exchange; otherwise the
 // exchange is skipped because its conditional variance would be degenerate.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::exchange()
 {
-    // Select an atom and its right neighbor, wrapping at the end of the domain.
+    // [AI-generated] Select an atom and its right neighbor, wrapping at the end of the domain.
     AtomNeighborhoodType hood = mDomain.randomAtomWithNeighbors(&mRng);
     AtomType *atom1 = hood.center;
-    // Exchange with the right neighbor, wrapping the last atom to the first.
+    // [AI-generated] Exchange with the right neighbor, wrapping the last atom to the first.
     AtomType *atom2 = hood.hasRight() ? hood.right : mDomain.front();
 
-    // Map both atom positions to matrix indices.
+    // [AI-generated] Map both atom positions to matrix indices.
     unsigned r1 = (atom1->pos() / mBinLength) / mNumPatterns;
     unsigned c1 = (atom1->pos() / mBinLength) % mNumPatterns;
     unsigned r2 = (atom2->pos() / mBinLength) / mNumPatterns;
     unsigned c2 = (atom2->pos() / mBinLength) % mNumPatterns;
 
-    // Same-bin exchanges only redistribute atomic mass and do not update matrix entries.
+    // [AI-generated] Same-bin exchanges only redistribute atomic mass and do not update matrix entries.
     if ((r1 != r2 || c1 != c2) && DataModel::canUseGibbs(c1, c2))
     {
         OptionalFloat mass = DataModel::sampleExchange(r1, c1, atom1->mass(),

--- a/src/gibbs_sampler/SingleThreadedGibbsSampler.h
+++ b/src/gibbs_sampler/SingleThreadedGibbsSampler.h
@@ -94,11 +94,16 @@ float SingleThreadedGibbsSampler<DataModel>::getAverageQueueLength() const
 template <class DataModel>
 char SingleThreadedGibbsSampler<DataModel>::getUpdateType() const
 {
+    // Move and exchange require existing atoms and neighboring atom positions.
+    // With fewer than two atoms, force birth so early model-fitting states do
+    // not create degenerate proposals with undefined conditional distributions.
     if (mDomain.size() < 2)
     {
         return 'B'; // always birth when no atoms exist
     }
 
+    // Choose among the four reversible-jump moves used by the atomic prior.
+    // Birth/death change the number of atoms; move/exchange preserve it.
     float u1 = mRng.uniform();
     if (u1 < 0.5f)
     {
@@ -113,6 +118,8 @@ char SingleThreadedGibbsSampler<DataModel>::getUpdateType() const
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nThreads) // NOLINT
 {
+    // Sequential sampler path: each proposal is generated, evaluated, and
+    // applied before the next proposal is drawn.
     for (unsigned i = 0; i < nSteps; ++i)
     {
         switch (getUpdateType())
@@ -125,22 +132,26 @@ void SingleThreadedGibbsSampler<DataModel>::update(unsigned nSteps, unsigned nTh
     }
 }
 
-// add an atom at a random position, calculate mass either with an
-// exponential distribution or with the gibbs mass distribution
+// Birth adds an atom at a random free position in the atomic domain. Early in
+// model fitting, the conditional Gibbs distribution may be undefined because
+// its variance term would require division by zero. In those cases, the atom
+// mass is sampled from the exponential prior so the full proposal can still be
+// evaluated.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::birth()
 {
-    // get random open position in atomic domain, calculate row and col of the position
+    // Map the atomic position to the matrix row and pattern column it updates.
     uint64_t pos = mDomain.randomFreePosition(&mRng);
     unsigned row = (pos / mBinLength) / mNumPatterns;
     unsigned col = (pos / mBinLength) % mNumPatterns;
 
-    // try to get mass using gibbs, resort to exponential if needed
+    // Sample mass using Gibbs when the conditional distribution is defined;
+    // fall back to the prior when the conditional variance would be degenerate.
     OptionalFloat mass = DataModel::canUseGibbs(col)
         ? DataModel::sampleBirth(row, col, &mRng)
         : mRng.exponential(DataModel::lambda());
 
-    // accept mass as long as gibbs succeded or it's non-zero
+    // Accept the birth when the proposed mass is valid and nonzero.
     if (mass.hasValue() && mass.value() > gaps::epsilon)
     {
         mDomain.insert(pos, mass.value());
@@ -148,16 +159,18 @@ void SingleThreadedGibbsSampler<DataModel>::birth()
     }
 }
 
-// automatically accept death, attempt a rebirth at the same position, using
-// the original mass or the gibbs mass distribution
+// Death removes an atom by first subtracting its mass from the matrix, then
+// attempting a rebirth at the same matrix element. When the conditional Gibbs
+// distribution is defined, it proposes the rebirth mass; otherwise the original
+// mass is retained so the full death/rebirth proposal can still be evaluated.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::death()
 {
-    // select atom at random and calculate it's row and col
+    // Select an atom and map its position to the matrix row and pattern column.
     AtomType *atom = mDomain.randomAtom(&mRng);
     unsigned row = (atom->pos() / mBinLength) / mNumPatterns;
     unsigned col = (atom->pos() / mBinLength) % mNumPatterns;
-    // determine mass to attempt rebirth with
+    // Determine the mass to attempt rebirth with.
     float rebirthMass = atom->mass(); // default rebirth mass == no change to atom
     AlphaParameters alpha = DataModel::alphaParametersWithChange(row, col, -1.f * atom->mass())
         * DataModel::annealingTemp();
@@ -170,7 +183,7 @@ void SingleThreadedGibbsSampler<DataModel>::death()
             rebirthMass = gMass.value();
         }
     }
-    // handle accept/reject of the rebirth
+    // Handle accept/reject of the rebirth step.
     float deltaLL = rebirthMass * (alpha.s_mu - alpha.s * rebirthMass / 2.f);
     if (std::log(mRng.uniform()) < deltaLL) // accept
     {
@@ -187,18 +200,20 @@ void SingleThreadedGibbsSampler<DataModel>::death()
     }
 }
 
-// move mass from src to dest in the atomic domain
+// Move shifts an existing atom to a new position between its neighboring atoms.
+// If the move crosses matrix elements, accept/reject is based on the resulting
+// change in likelihood.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::move()
 {
-    // select atom at random and get it's right and left neighbors
+    // Select an atom and its left/right neighbors to preserve atomic ordering.
     AtomNeighborhoodType hood = mDomain.randomAtomWithNeighbors(&mRng);
     AtomType *atom = hood.center;
     uint64_t lbound = hood.hasLeft() ? hood.left->pos() : 0;
     uint64_t rbound = hood.hasRight() ? hood.right->pos() :
         static_cast<uint64_t>(mDomainLength);
 
-    // randomly select new position to move to and calculation the row and col of it
+    // Select the new atomic position and map old/new positions to matrix indices.
     uint64_t pos = mRng.uniform64(lbound + 1, rbound - 1);
     unsigned r1 = (atom->pos() / mBinLength) / mNumPatterns;
     unsigned c1 = (atom->pos() / mBinLength) % mNumPatterns;
@@ -212,7 +227,7 @@ void SingleThreadedGibbsSampler<DataModel>::move()
         return;
     }
     
-    // conditionally accept move based on change to likelihood
+    // Conditionally accept moves that change matrix elements.
     float deltaLL = DataModel::deltaLogLikelihood(r1, c1, r2, c2, atom->mass());
     if (std::log(mRng.uniform()) < deltaLL)
     {
@@ -222,23 +237,25 @@ void SingleThreadedGibbsSampler<DataModel>::move()
     }
 }
 
-// exchange some amount of mass between two positions, note it is possible
-// for one of the atoms to be deleted if it's mass becomes too small
+// Exchange transfers mass between neighboring atoms. When the two atoms affect
+// different matrix elements and the conditional Gibbs distribution is defined,
+// that distribution proposes the amount of mass to exchange; otherwise the
+// exchange is skipped because its conditional variance would be degenerate.
 template <class DataModel>
 void SingleThreadedGibbsSampler<DataModel>::exchange()
 {
-    // select atom at random and get it's right neighbor
+    // Select an atom and its right neighbor, wrapping at the end of the domain.
     AtomNeighborhoodType hood = mDomain.randomAtomWithNeighbors(&mRng);
     AtomType *atom1 = hood.center;
     AtomType *atom2 = hood.hasRight() ? hood.right : mDomain.front();
 
-    // calculate row and col of the atom and it's neighbor
+    // Map both atom positions to matrix indices.
     unsigned r1 = (atom1->pos() / mBinLength) / mNumPatterns;
     unsigned c1 = (atom1->pos() / mBinLength) % mNumPatterns;
     unsigned r2 = (atom2->pos() / mBinLength) / mNumPatterns;
     unsigned c2 = (atom2->pos() / mBinLength) % mNumPatterns;
 
-    // ignore exchanges in the same bin
+    // Same-bin exchanges only redistribute atomic mass and do not update matrix entries.
     if ((r1 != r2 || c1 != c2) && DataModel::canUseGibbs(c1, c2))
     {
         OptionalFloat mass = DataModel::sampleExchange(r1, c1, atom1->mass(),

--- a/src/gibbs_sampler/SparseNormalModel.cpp
+++ b/src/gibbs_sampler/SparseNormalModel.cpp
@@ -10,6 +10,8 @@
 #define GAPS_SQ(x) ((x) * (x))
 
 #define COUNT_LOWER_BITS(u, pos) __builtin_popcountll((u) & ((1ull << (pos)) - 1ull))
+// Clear all bits up to and including pos; shifting by 64 is undefined, so pos
+// 63 is handled explicitly.
 #define CLEAR_LOWER_BITS(u, pos) (((pos) == 63) ? 0 : (u) & ~((1ull << ((pos) + 1ull)) - 1ull))
 #define COUNT_BITS(u) __builtin_popcountll(u)
 #define GET_FIRST_SET_BIT(u) (__builtin_ffsll(u) - 1)

--- a/src/gibbs_sampler/SparseNormalModel.cpp
+++ b/src/gibbs_sampler/SparseNormalModel.cpp
@@ -10,7 +10,7 @@
 #define GAPS_SQ(x) ((x) * (x))
 
 #define COUNT_LOWER_BITS(u, pos) __builtin_popcountll((u) & ((1ull << (pos)) - 1ull))
-// Clear all bits up to and including pos; shifting by 64 is undefined, so pos
+// [AI-generated] Clear all bits up to and including pos; shifting by 64 is undefined, so pos
 // 63 is handled explicitly.
 #define CLEAR_LOWER_BITS(u, pos) (((pos) == 63) ? 0 : (u) & ~((1ull << ((pos) + 1ull)) - 1ull))
 #define COUNT_BITS(u) __builtin_popcountll(u)
@@ -323,4 +323,3 @@ Archive& operator>>(Archive &ar, SparseNormalModel &m)
     ar >> m.mMatrix >> m.mBeta;
     return ar;
 }
-

--- a/src/math/Math.cpp
+++ b/src/math/Math.cpp
@@ -12,37 +12,37 @@
 
 float gaps::min(float a, float b)
 {
-    // Return the smaller value: if a is less than b choose a, otherwise choose b.
+    // [AI-generated] Return the smaller value: if a is less than b choose a, otherwise choose b.
     return a < b ? a : b;
 }
 
 unsigned gaps::min(unsigned a, unsigned b)
 {
-    // Return the smaller value: if a is less than b choose a, otherwise choose b.
+    // [AI-generated] Return the smaller value: if a is less than b choose a, otherwise choose b.
     return a < b ? a : b;
 }
 
 uint64_t gaps::min(uint64_t a, uint64_t b)
 {
-    // Return the smaller value: if a is less than b choose a, otherwise choose b.
+    // [AI-generated] Return the smaller value: if a is less than b choose a, otherwise choose b.
     return a < b ? a : b;
 }
 
 float gaps::max(float a, float b)
 {
-    // Return the larger value: if a is less than b choose b, otherwise choose a.
+    // [AI-generated] Return the larger value: if a is less than b choose b, otherwise choose a.
     return a < b ? b : a;
 }
 
 unsigned gaps::max(unsigned a, unsigned b)
 {
-    // Return the larger value: if a is less than b choose b, otherwise choose a.
+    // [AI-generated] Return the larger value: if a is less than b choose b, otherwise choose a.
     return a < b ? b : a;
 }
 
 uint64_t gaps::max(uint64_t a, uint64_t b)
 {
-    // Return the larger value: if a is less than b choose b, otherwise choose a.
+    // [AI-generated] Return the larger value: if a is less than b choose b, otherwise choose a.
     return a < b ? b : a;
 }
 

--- a/src/math/Math.cpp
+++ b/src/math/Math.cpp
@@ -12,31 +12,37 @@
 
 float gaps::min(float a, float b)
 {
+    // Return the smaller value: if a is less than b choose a, otherwise choose b.
     return a < b ? a : b;
 }
 
 unsigned gaps::min(unsigned a, unsigned b)
 {
+    // Return the smaller value: if a is less than b choose a, otherwise choose b.
     return a < b ? a : b;
 }
 
 uint64_t gaps::min(uint64_t a, uint64_t b)
 {
+    // Return the smaller value: if a is less than b choose a, otherwise choose b.
     return a < b ? a : b;
 }
 
 float gaps::max(float a, float b)
 {
+    // Return the larger value: if a is less than b choose b, otherwise choose a.
     return a < b ? b : a;
 }
 
 unsigned gaps::max(unsigned a, unsigned b)
 {
+    // Return the larger value: if a is less than b choose b, otherwise choose a.
     return a < b ? b : a;
 }
 
 uint64_t gaps::max(uint64_t a, uint64_t b)
 {
+    // Return the larger value: if a is less than b choose b, otherwise choose a.
     return a < b ? b : a;
 }
 

--- a/src/math/MatrixMath.h
+++ b/src/math/MatrixMath.h
@@ -37,6 +37,7 @@ float gaps::min(const MatrixType &mat)
     for (unsigned i = 0; i < mat.nCol(); ++i)
     {
         float cmin = gaps::min(mat.getCol(i));
+        // Keep the smallest column minimum seen so far.
         mn = (cmin < mn) ? cmin : mn;
     }
     return mn;
@@ -49,6 +50,7 @@ float gaps::max(const MatrixType &mat)
     for (unsigned i = 0; i < mat.nCol(); ++i)
     {
         float cmax = gaps::max(mat.getCol(i));
+        // Keep the largest column maximum seen so far.
         mx = (cmax > mx) ? cmax : mx;
     }
     return mx;

--- a/src/math/MatrixMath.h
+++ b/src/math/MatrixMath.h
@@ -37,7 +37,7 @@ float gaps::min(const MatrixType &mat)
     for (unsigned i = 0; i < mat.nCol(); ++i)
     {
         float cmin = gaps::min(mat.getCol(i));
-        // Keep the smallest column minimum seen so far.
+        // [AI-generated] Keep the smallest column minimum seen so far.
         mn = (cmin < mn) ? cmin : mn;
     }
     return mn;
@@ -50,7 +50,7 @@ float gaps::max(const MatrixType &mat)
     for (unsigned i = 0; i < mat.nCol(); ++i)
     {
         float cmax = gaps::max(mat.getCol(i));
-        // Keep the largest column maximum seen so far.
+        // [AI-generated] Keep the largest column maximum seen so far.
         mx = (cmax > mx) ? cmax : mx;
     }
     return mx;

--- a/src/math/Random.cpp
+++ b/src/math/Random.cpp
@@ -126,6 +126,8 @@ uint64_t GapsRng::uniform64(uint64_t a, uint64_t b)
 
 int GapsRng::poisson(double lambda)
 {
+    // Use inversion for small Poisson means; otherwise use the large-mean
+    // rejection sampler.
     return lambda <= 5.0 ? poissonSmall(lambda) : poissonLarge(lambda);
 }
 

--- a/src/math/Random.cpp
+++ b/src/math/Random.cpp
@@ -34,7 +34,7 @@ GapsRng::GapsRng(GapsRandomState *randState)
 mRandState(randState),
 mState(randState->nextSeed())
 {
-    // Pull exactly one seed from the run-level seeder, then advance once so a
+    // [AI-generated] Pull exactly one seed from the run-level seeder, then advance once so a
     // new GapsRng does not begin by returning its seed state.
     advance();
 }
@@ -126,7 +126,7 @@ uint64_t GapsRng::uniform64(uint64_t a, uint64_t b)
 
 int GapsRng::poisson(double lambda)
 {
-    // Use inversion for small Poisson means; otherwise use the large-mean
+    // [AI-generated] Use inversion for small Poisson means; otherwise use the large-mean
     // rejection sampler.
     return lambda <= 5.0 ? poissonSmall(lambda) : poissonLarge(lambda);
 }
@@ -300,14 +300,14 @@ void GapsRandomState::initLookupTables()
 
 uint64_t GapsRandomState::nextSeed()
 {
-    // Hands out deterministic seeds for local GapsRng streams. The order in
+    // [AI-generated] Hands out deterministic seeds for local GapsRng streams. The order in
     // which callers request seeds determines the downstream RNG streams.
     return mSeeder.next();
 }
 
 void GapsRandomState::rollBackOnce()
 {
-    // Used when a just-created local RNG cannot be used, so the same seed can
+    // [AI-generated] Used when a just-created local RNG cannot be used, so the same seed can
     // be retried during the next proposal attempt.
     mSeeder.rollBackOnce();
 }

--- a/src/math/Random.cpp
+++ b/src/math/Random.cpp
@@ -34,6 +34,8 @@ GapsRng::GapsRng(GapsRandomState *randState)
 mRandState(randState),
 mState(randState->nextSeed())
 {
+    // Pull exactly one seed from the run-level seeder, then advance once so a
+    // new GapsRng does not begin by returning its seed state.
     advance();
 }
 
@@ -296,11 +298,15 @@ void GapsRandomState::initLookupTables()
 
 uint64_t GapsRandomState::nextSeed()
 {
+    // Hands out deterministic seeds for local GapsRng streams. The order in
+    // which callers request seeds determines the downstream RNG streams.
     return mSeeder.next();
 }
 
 void GapsRandomState::rollBackOnce()
 {
+    // Used when a just-created local RNG cannot be used, so the same seed can
+    // be retried during the next proposal attempt.
     mSeeder.rollBackOnce();
 }
 

--- a/src/math/Random.h
+++ b/src/math/Random.h
@@ -26,7 +26,7 @@ private :
     bool mHasValue;
 };
 
-// PCG random number generator. Each GapsRng is constructed with a seed pulled
+// [AI-generated] PCG random number generator. Each GapsRng is constructed with a seed pulled
 // from GapsRandomState, then advances independently from that run-level seeder.
 class GapsRng
 {
@@ -69,7 +69,7 @@ private:
     uint64_t mPreviousState[2];
 };
 
-// Manages the run-level seed stream and lookup tables for distribution
+// [AI-generated] Manages the run-level seed stream and lookup tables for distribution
 // functions. This object is created once at the beginning of execution and
 // passed down to classes that need local GapsRng streams, avoiding global RNG
 // state during multi-threaded execution.
@@ -95,4 +95,4 @@ private:
     GapsRandomState& operator=(const GapsRandomState&); // = delete (no c++11)
 };
 
-#endif // __COGAPS_RANDOM_H__
+#endif // [AI-generated] __COGAPS_RANDOM_H__

--- a/src/math/Random.h
+++ b/src/math/Random.h
@@ -26,9 +26,8 @@ private :
     bool mHasValue;
 };
 
-// TODO allow this to be rolled back
-// PCG random number generator
-// This is constructed with a seed pulled from the global state
+// PCG random number generator. Each GapsRng is constructed with a seed pulled
+// from GapsRandomState, then advances independently from that run-level seeder.
 class GapsRng
 {
 public:
@@ -70,10 +69,10 @@ private:
     uint64_t mPreviousState[2];
 };
 
-// manages random seed and lookup tables for distribution functions, need to
-// avoid global variables for multi-threading issues - this random state
-// is created at the beginning of execution and passed down to the classes
-// that need it
+// Manages the run-level seed stream and lookup tables for distribution
+// functions. This object is created once at the beginning of execution and
+// passed down to classes that need local GapsRng streams, avoiding global RNG
+// state during multi-threaded execution.
 class GapsRandomState
 {
 public:

--- a/src/math/VectorMath.cpp
+++ b/src/math/VectorMath.cpp
@@ -7,7 +7,7 @@ float gaps::min(const Vector &v)
     float mn = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
-        // Keep the smaller value seen so far.
+        // [AI-generated] Keep the smaller value seen so far.
         mn = (v[i] < mn) ? v[i] : mn;
     }
     return mn;
@@ -18,7 +18,7 @@ float gaps::min(const HybridVector &v)
     float mn = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
-        // Keep the smaller value seen so far.
+        // [AI-generated] Keep the smaller value seen so far.
         mn = (v[i] < mn) ? v[i] : mn;
     }
     return mn;
@@ -30,7 +30,7 @@ float gaps::min(const SparseVector &v)
     SparseIterator<1> it(v);
     while (!it.atEnd())
     {
-        // Keep the smaller nonzero sparse value seen so far.
+        // [AI-generated] Keep the smaller nonzero sparse value seen so far.
         mn = (get<1>(it) < mn) ? get<1>(it) : mn;
         it.next();
     }
@@ -42,7 +42,7 @@ float gaps::max(const Vector &v)
     float mx = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
-        // Keep the larger value seen so far.
+        // [AI-generated] Keep the larger value seen so far.
         mx = (v[i] > mx) ? v[i] : mx;
     }
     return mx;
@@ -53,7 +53,7 @@ float gaps::max(const HybridVector &v)
     float mx = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
-        // Keep the larger value seen so far.
+        // [AI-generated] Keep the larger value seen so far.
         mx = (v[i] > mx) ? v[i] : mx;
     }
     return mx;
@@ -65,7 +65,7 @@ float gaps::max(const SparseVector &v)
     SparseIterator<1> it(v);
     while (!it.atEnd())
     {
-        // Keep the larger nonzero sparse value seen so far.
+        // [AI-generated] Keep the larger nonzero sparse value seen so far.
         mx = (get<1>(it) > mx) ? get<1>(it) : mx;
         it.next();
     }
@@ -78,7 +78,7 @@ unsigned gaps::whichMax(const Vector &v)
     float mx = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
-        // Track the index and value of the largest entry seen so far.
+        // [AI-generated] Track the index and value of the largest entry seen so far.
         ndx = (v[i] > mx) ? i : ndx;
         mx = (v[i] > mx) ? v[i] : mx;
     }

--- a/src/math/VectorMath.cpp
+++ b/src/math/VectorMath.cpp
@@ -7,6 +7,7 @@ float gaps::min(const Vector &v)
     float mn = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
+        // Keep the smaller value seen so far.
         mn = (v[i] < mn) ? v[i] : mn;
     }
     return mn;
@@ -17,6 +18,7 @@ float gaps::min(const HybridVector &v)
     float mn = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
+        // Keep the smaller value seen so far.
         mn = (v[i] < mn) ? v[i] : mn;
     }
     return mn;
@@ -28,6 +30,7 @@ float gaps::min(const SparseVector &v)
     SparseIterator<1> it(v);
     while (!it.atEnd())
     {
+        // Keep the smaller nonzero sparse value seen so far.
         mn = (get<1>(it) < mn) ? get<1>(it) : mn;
         it.next();
     }
@@ -39,6 +42,7 @@ float gaps::max(const Vector &v)
     float mx = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
+        // Keep the larger value seen so far.
         mx = (v[i] > mx) ? v[i] : mx;
     }
     return mx;
@@ -49,6 +53,7 @@ float gaps::max(const HybridVector &v)
     float mx = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
+        // Keep the larger value seen so far.
         mx = (v[i] > mx) ? v[i] : mx;
     }
     return mx;
@@ -60,6 +65,7 @@ float gaps::max(const SparseVector &v)
     SparseIterator<1> it(v);
     while (!it.atEnd())
     {
+        // Keep the larger nonzero sparse value seen so far.
         mx = (get<1>(it) > mx) ? get<1>(it) : mx;
         it.next();
     }
@@ -72,6 +78,7 @@ unsigned gaps::whichMax(const Vector &v)
     float mx = 0.f;
     for (unsigned i = 0; i < v.size(); ++i)
     {
+        // Track the index and value of the largest entry seen so far.
         ndx = (v[i] > mx) ? i : ndx;
         mx = (v[i] > mx) ? v[i] : mx;
     }

--- a/src/test-runner.cpp
+++ b/src/test-runner.cpp
@@ -32,6 +32,7 @@ int run_catch_unit_tests(Rcpp::String reporter="console")
   //the next line does not work here.. actually, works only one time
   //session.configData().reporterNames.push_back(reporter);
   int numFailed = session.run();
+  // Cap the process exit code at 255, the largest portable single-byte status.
   return (numFailed < 0xFF ? numFailed : 0xFF);
 }
 
@@ -54,5 +55,6 @@ int run_catch_unit_tests_by_tag(Rcpp::String tag="",Rcpp::String reporter="conso
   cfg.reporterNames.push_back(reporter);
   session.useConfigData(cfg);
   int numFailed = session.run();
+  // Cap the process exit code at 255, the largest portable single-byte status.
   return (numFailed < 0xFF ? numFailed : 0xFF);
 }

--- a/src/test-runner.cpp
+++ b/src/test-runner.cpp
@@ -32,7 +32,7 @@ int run_catch_unit_tests(Rcpp::String reporter="console")
   //the next line does not work here.. actually, works only one time
   //session.configData().reporterNames.push_back(reporter);
   int numFailed = session.run();
-  // Cap the process exit code at 255, the largest portable single-byte status.
+  // [AI-generated] Cap the process exit code at 255, the largest portable single-byte status.
   return (numFailed < 0xFF ? numFailed : 0xFF);
 }
 
@@ -55,6 +55,6 @@ int run_catch_unit_tests_by_tag(Rcpp::String tag="",Rcpp::String reporter="conso
   cfg.reporterNames.push_back(reporter);
   session.useConfigData(cfg);
   int numFailed = session.run();
-  // Cap the process exit code at 255, the largest portable single-byte status.
+  // [AI-generated] Cap the process exit code at 255, the largest portable single-byte status.
   return (numFailed < 0xFF ? numFailed : 0xFF);
 }


### PR DESCRIPTION
This pull request focuses on improving the clarity, reproducibility, and platform-compatibility of the CoGAPS package. The changes enhance user feedback regarding OpenMP availability, clarify parallelism behavior in distributed runs, and add a new script to debug reproducibility across compilers and platforms. Additionally, the C++ codebase has been augmented with explanatory comments for better maintainability and understanding.

**Parallelism and OpenMP Handling:**

* Improved user warnings and enforced single-threaded, sequential execution when OpenMP is unavailable, both in standard and distributed CoGAPS runs. This ensures users are aware of platform-dependent behavior and avoids silent changes in results. [[1]](diffhunk://#diff-c66bfcc51ac5c31fe1594b92bb832912b6e8d44c1b577f8ffc32a4eeddfce812L107-R116) [[2]](diffhunk://#diff-714acb5ddf8d1c824a18ddb29aedfd0cfd5e3cc067df9c827b63b6b088bf2cccR28-R31) [[3]](diffhunk://#diff-8067449a6b41e7cd7576511834e25b2c3512490986d2b5925b89d2b9a673beedL235-R240)

**Reproducibility and Debugging:**

* Added a new script `inst/scripts/debugCompilerReproducibilityFingerprint.R` to systematically test and fingerprint CoGAPS results across different compilers and platforms, aiding reproducibility investigations.

**Documentation and Logging Improvements:**

* Enhanced C++ code with detailed, AI-generated comments explaining logic in parameter handling, atomic domain operations, proposal queues, and test cases. This improves code readability and maintainability for future developers. [[1]](diffhunk://#diff-9c4215c2271376fde88982904826d93f0f6d5a8d5fb0e85f7fc182fce6324b6dR10) [[2]](diffhunk://#diff-9c4215c2271376fde88982904826d93f0f6d5a8d5fb0e85f7fc182fce6324b6dR57) [[3]](diffhunk://#diff-9c4215c2271376fde88982904826d93f0f6d5a8d5fb0e85f7fc182fce6324b6dR72) [[4]](diffhunk://#diff-bbc95126b2210dec1feef49fc2016df1c919051734b60cc5dacc1c1534912692R115) [[5]](diffhunk://#diff-bbc95126b2210dec1feef49fc2016df1c919051734b60cc5dacc1c1534912692R152-R164) [[6]](diffhunk://#diff-9484add28d01311d7ed9d068699b5f3d9b7e1422b9e8abc9af2a6b8b3965dea0R138-R139) [[7]](diffhunk://#diff-34550ecdde3363a5257fbe9943eb96fde0b0b44a5c0eae9e90180ba8b5167959R36-R37) [[8]](diffhunk://#diff-34550ecdde3363a5257fbe9943eb96fde0b0b44a5c0eae9e90180ba8b5167959R117-R118) [[9]](diffhunk://#diff-f0717317022c121f3a676b43d27d4b177acc5aeaea7342568d154d439ac78b35R128-R129) [[10]](diffhunk://#diff-d09610a2544c643596b09c64f71d5318e53b0830adf267109288c6a1f8e9a27aR131-R132) [[11]](diffhunk://#diff-d09610a2544c643596b09c64f71d5318e53b0830adf267109288c6a1f8e9a27aR161) [[12]](diffhunk://#diff-d09610a2544c643596b09c64f71d5318e53b0830adf267109288c6a1f8e9a27aR218-R219) [[13]](diffhunk://#diff-d09610a2544c643596b09c64f71d5318e53b0830adf267109288c6a1f8e9a27aR260) [[14]](diffhunk://#diff-d09610a2544c643596b09c64f71d5318e53b0830adf267109288c6a1f8e9a27aR276) [[15]](diffhunk://#diff-2f1af0b8e12922fd4df411fbca2406989468ce6e62e0e89c16f525993046ed37R70-L78) [[16]](diffhunk://#diff-3b06c08d05b4e3fe9191f75576c58c1fc1fa9a5c5ee4339b6dd39d8467121366R22-R23) [[17]](diffhunk://#diff-531d330f473e1fb5e0c22f70fc74115ed2e51d4f85fb8dcfcde3f49bf5017e2fR52-R53) [[18]](diffhunk://#diff-531d330f473e1fb5e0c22f70fc74115ed2e51d4f85fb8dcfcde3f49bf5017e2fR80-R81)

**Version Update:**

* Incremented package version to 3.33.1 to reflect these changes.